### PR TITLE
Fix admin delete and replace popups with modal overlays

### DIFF
--- a/src/components/AgeGate.tsx
+++ b/src/components/AgeGate.tsx
@@ -1,13 +1,27 @@
 "use client";
-import { useEffect } from "react";
+import { useState } from "react";
+import Modal from "./Modal";
 
 export default function AgeGate() {
-  useEffect(() => {
-    const ok = confirm("You must be 21+. Click OK to proceed.");
-    if (ok) {
-      document.cookie = "ageVerify=true; path=/; max-age=" + 60*60*24*30;
-      window.location.reload();
-    }
-  }, []);
-  return null;
+  const [open, setOpen] = useState(true);
+
+  const confirmAge = () => {
+    document.cookie = "ageVerify=true; path=/; max-age=" + 60 * 60 * 24 * 30;
+    setOpen(false);
+    window.location.reload();
+  };
+
+  return (
+    <Modal isOpen={open} onClose={() => {}}>
+      <p className="text-center mb-4">You must be 21+. Click below to proceed.</p>
+      <div className="text-center">
+        <button
+          onClick={confirmAge}
+          className="px-4 py-2 bg-green-600 text-white rounded"
+        >
+          I'm 21 or older
+        </button>
+      </div>
+    </Modal>
+  );
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { ReactNode } from "react";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function Modal({ isOpen, onClose, children }: ModalProps) {
+  if (!isOpen) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white rounded shadow-lg p-4 max-w-sm w-full">
+        {children}
+        <div className="mt-4 text-right">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add generic `Modal` component
- show AgeGate as modal overlay instead of browser confirm
- remove logo column from the admin panel
- show delete confirmation using modal overlay and update state after delete

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6853630783bc832d8b0ea1277de6c6f2