### PR TITLE
Fix admin delete and ordering

### DIFF
--- a/prisma/migrations/20250619014934_cascade_delete_producer/migration.sql
+++ b/prisma/migrations/20250619014934_cascade_delete_producer/migration.sql
@@ -1,0 +1,3 @@
+-- Alter foreign key to cascade delete votes when a producer is removed
+ALTER TABLE "Vote" DROP CONSTRAINT IF EXISTS "Vote_producerId_fkey";
+ALTER TABLE "Vote" ADD CONSTRAINT "Vote_producerId_fkey" FOREIGN KEY ("producerId") REFERENCES "Producer"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -30,11 +30,15 @@ export default function AdminPage() {
           throw new Error(data.error);
         }
 
-        const combinedProducers = [...(data.flower || []), ...(data.hash || [])].sort((a, b) => {
-          const nameA = a.name || '';
-          const nameB = b.name || '';
-          return nameA.localeCompare(nameB);
-        });
+        const combinedProducers = [...(data.flower || []), ...(data.hash || [])].sort(
+          (a, b) => {
+            const typeCompare = (a.category || '').localeCompare(b.category || '');
+            if (typeCompare !== 0) return typeCompare;
+            const nameA = a.name || '';
+            const nameB = b.name || '';
+            return nameA.localeCompare(nameB);
+          }
+        );
         setProducers(combinedProducers);
       } catch (err: any) {
         setError(err.message);
@@ -56,6 +60,7 @@ export default function AdminPage() {
     try {
       const response = await fetch(`/api/producers/${confirmData.id}`, {
         method: "DELETE",
+        credentials: "include",
       });
       if (response.ok) {
         setProducers(producers.filter((p) => p.id !== confirmData.id));


### PR DESCRIPTION
## Summary
- add vote cascade delete migration
- sort admin table by producer type then name
- include credentials in admin delete fetch

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68536c30f7b4832d905e1e5990034c76