### PR TITLE
Disable prepared statements in Prisma client

### DIFF
--- a/src/lib/prismadb.ts
+++ b/src/lib/prismadb.ts
@@ -1,9 +1,25 @@
 import { PrismaClient } from "@prisma/client";
 
 declare global {
-  // to avoid multiple instances in dev
+  // avoid multiple instances in development
+  // eslint-disable-next-line no-var
   var prisma: PrismaClient | undefined;
 }
 
-export const prisma = global.prisma || new PrismaClient();
-if (process.env.NODE_ENV !== "production") global.prisma = prisma;
+// Disable prepared statements when using a direct connection to
+// avoid `bind message` errors. The query engine recognizes the
+// `pgbouncer=true` parameter and switches to simple query mode.
+const baseUrl = process.env.DIRECT_URL || process.env.DATABASE_URL;
+const url = baseUrl?.includes("pgbouncer=true")
+  ? baseUrl
+  : `${baseUrl}?pgbouncer=true`;
+
+export const prisma =
+  global.prisma ||
+  new PrismaClient({
+    datasourceUrl: url,
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  global.prisma = prisma;
+}


### PR DESCRIPTION
## Summary
- disable prepared statements by appending `pgbouncer=true` to the connection string

## Testing
- `npm run build` *(fails: Type error: Route `src/app/api/producers/[id]/route.ts` has an invalid `DELETE` export)*

------
https://chatgpt.com/codex/tasks/task_e_6853a9e56a34832dab125512909df482