### PR TITLE
Switch profile pages to use user id

### DIFF
--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prismadb";
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+
+export async function GET() {
+  const supabase = createServerActionClient({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.user?.email) {
+    return NextResponse.json(
+      { success: false, error: "Not authenticated" },
+      { status: 401 }
+    );
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+  });
+
+  if (!user) {
+    return NextResponse.json(
+      { success: false, error: "User not found" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ success: true, id: user.id });
+}

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,17 +1,16 @@
-// src/app/profile/[email]/page.tsx
+// src/app/profile/[id]/page.tsx
 import ProducerCard from "@/components/ProducerCard";
 import { prisma } from "@/lib/prismadb";
 
 export default async function ProfilePage({
   params,
 }: {
-  params: { email: string }; // Parameter changed to email
+  params: { id: string };
 }) {
-  const { email: encodedEmail } = params; // Destructure and rename
-  const email = decodeURIComponent(encodedEmail); // Decode email
+  const { id } = params;
 
   const user = await prisma.user.findUnique({
-    where: { email }, // Query by email
+    where: { id }, // Query by id
     include: {
       votes: {
         // producer.votes is needed for ProducerCard to calculate total score
@@ -22,7 +21,7 @@ export default async function ProfilePage({
 
   if (!user) {
     // Consider a more user-friendly "not found" page or redirect
-    return <p>User not found. (Email: {email})</p>; // Updated message for email
+    return <p>User not found. (ID: {id})</p>;
   }
 
   // Process votes into liked and disliked producers


### PR DESCRIPTION
## Summary
- route `/profile/[id]` to show a user's profile
- fetch a logged-in user's id via `/api/users/me`
- update Navbar to link to `/profile/<id>` using that API

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run build` *(fails: type errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68543730ae44832da6d69fba7e111a87