### PR TITLE
Fix route signature and update async parameters

### DIFF
--- a/src/app/api/producers/[id]/route.ts
+++ b/src/app/api/producers/[id]/route.ts
@@ -1,17 +1,14 @@
 // src/app/api/producers/[id]/route.ts
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prismadb";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs"; // Correct import for Route Handlers
 import { cookies } from "next/headers";
 import { Role } from "@prisma/client";
 
-interface DeleteParams {
-  params: {
-    id: string;
-  };
-}
-
-export async function DELETE(request: Request, { params }: DeleteParams) {
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
   try {
     // 1. Authentication & Authorization
     const supabase = createServerActionClient({ cookies }); // Use createServerActionClient for Route Handlers
@@ -39,7 +36,7 @@ export async function DELETE(request: Request, { params }: DeleteParams) {
     }
 
     // 2. Deletion Logic
-    const producerId = params.id;
+    const { id: producerId } = await params;
 
     if (!producerId) {
       return NextResponse.json(

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import { Category, Vote } from "@prisma/client";
 
 export default async function HomePage() {
   // 1) Age‐gate
-  const cookieStore = cookies(); // No await needed here
+  const cookieStore = await cookies();
   const is21 = cookieStore.get("ageVerify")?.value === "true";
   if (!is21) return <AgeGate />;
 

--- a/src/app/producer/[id]/page.tsx
+++ b/src/app/producer/[id]/page.tsx
@@ -7,13 +7,13 @@ import { Category } from "@prisma/client"; // Import Category enum if needed for
 const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
 
 interface ProducerProfilePageProps {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
 export default async function ProducerProfilePage({ params }: ProducerProfilePageProps) {
-  const { id } = params;
+  const { id } = await params;
 
   const producer = await prisma.producer.findUnique({
     where: { id },

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -5,9 +5,9 @@ import { prisma } from "@/lib/prismadb";
 export default async function ProfilePage({
   params,
 }: {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }) {
-  const { id } = params;
+  const { id } = await params;
 
   const user = await prisma.user.findUnique({
     where: { id }, // Query by id


### PR DESCRIPTION
## Summary
- fix DELETE handler parameter type in producers API route
- await cookies in `HomePage`
- adjust producer and profile pages to use async route params

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: NEXT_PUBLIC_SUPABASE_URL and other env vars missing)*

------
https://chatgpt.com/codex/tasks/task_e_685440f33514832db83b3dbf334ddd90