### PR TITLE
Fix login page suspense and update Supabase client

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,36 +1,38 @@
-// src/app/login/page.tsx
 "use client";
 
-import { useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation"; // Added useSearchParams
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
 
-export default function LoginPage() {
+function LoginForm() {
   const router = useRouter();
-  const searchParams = useSearchParams(); // Get search params
-  const reason = searchParams.get("reason"); // Get reason query param
-  const [email, setEmail]       = useState("");
+  const searchParams = useSearchParams();
+  const reason = searchParams.get("reason");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [error, setError]       = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const handleAuth = async () => {
-    // 1) Try to sign in
-    const { data: signInData, error: signInError } =
-      await supabase.auth.signInWithPassword({ email, password });
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
 
     if (signInError) {
-      // 2) If sign-in fails, try to sign up the user
-      const { data: signUpData, error: signUpError } =
-        await supabase.auth.signUp({ email, password });
+      const { error: signUpError } = await supabase.auth.signUp({
+        email,
+        password,
+      });
 
       if (signUpError) {
         setError(signUpError.message);
         return;
       }
 
-      // 3) After sign-up, immediately sign in
-      const { data: signIn2Data, error: signIn2Error } =
-        await supabase.auth.signInWithPassword({ email, password });
+      const { error: signIn2Error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
 
       if (signIn2Error) {
         setError(signIn2Error.message);
@@ -38,7 +40,6 @@ export default function LoginPage() {
       }
     }
 
-    // 4) If we have a session, redirect to admin
     const {
       data: { session },
       error: finalError,
@@ -60,8 +61,11 @@ export default function LoginPage() {
         </div>
       )}
       <h1 className="text-2xl mb-4 text-center font-semibold">Log In / Sign Up</h1>
-      {error && <div className="text-red-500 mb-2 p-3 bg-red-100 border border-red-400 rounded">{error}</div>}
-
+      {error && (
+        <div className="text-red-500 mb-2 p-3 bg-red-100 border border-red-400 rounded">
+          {error}
+        </div>
+      )}
       <button
         onClick={() => supabase.auth.signInWithOAuth({ provider: "google" })}
         className="w-full mb-2 py-2.5 bg-red-600 hover:bg-red-700 text-white rounded-md transition duration-150"
@@ -74,13 +78,11 @@ export default function LoginPage() {
       >
         Continue with Discord
       </button>
-
       <div className="relative flex py-3 items-center">
         <div className="flex-grow border-t border-gray-300"></div>
         <span className="flex-shrink mx-4 text-gray-400">Or</span>
         <div className="flex-grow border-t border-gray-300"></div>
       </div>
-
       <input
         type="email"
         placeholder="Email"
@@ -95,7 +97,6 @@ export default function LoginPage() {
         onChange={(e) => setPassword(e.target.value)}
         className="w-full mb-6 p-2.5 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
       />
-
       <button
         onClick={handleAuth}
         className="w-full py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition duration-150"
@@ -103,5 +104,13 @@ export default function LoginPage() {
         Log In / Sign Up with Email
       </button>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,4 +1,4 @@
 // src/lib/supabaseClient.ts
-import { createBrowserSupabaseClient } from "@supabase/auth-helpers-nextjs";
+import { createPagesBrowserClient } from "@supabase/auth-helpers-nextjs";
 
-export const supabase = createBrowserSupabaseClient();
+export const supabase = createPagesBrowserClient();


### PR DESCRIPTION
## Summary
- use `createPagesBrowserClient` in the Supabase helper
- wrap login page content in a `<Suspense>` boundary to satisfy `useSearchParams`

## Testing
- `npm run lint` *(fails: prompt to set up ESLint)*
- `npm run build` *(fails: missing Supabase env vars)*

------
https://chatgpt.com/codex/tasks/task_e_685443220144832d81ca05e6b58ef5bd