### PR TITLE
Switch Next.js config to commonjs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // any required config options
+};
+
+module.exports = nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,12 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "next.config.js"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- migrate Next.js configuration file to `.js`
- use CommonJS `module.exports`
- add `next.config.js` to `tsconfig.json` include list

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685457b52f68832db13dfc8cef5ca734