### PR TITLE
Show producer with profile comments and highlight user's comment

### DIFF
--- a/src/app/producer/[id]/page.tsx
+++ b/src/app/producer/[id]/page.tsx
@@ -152,7 +152,7 @@ export default async function ProducerProfilePage({ params }: ProducerProfilePag
         <div className="mt-8">
           <h3 className="text-xl font-semibold mb-4">Comments ({producer._count?.comments ?? 0})</h3>
           {userComment ? (
-            <CommentCard comment={userComment} currentUserId={currentUserId ?? undefined} />
+            <CommentCard comment={userComment} currentUserId={currentUserId ?? undefined} highlighted />
           ) : (
             <AddCommentForm producerId={id} />
           )}

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -12,9 +12,18 @@ export interface CommentData {
   userId: string;
   producerId: string;
   updatedAt: string | Date;
+  producer?: { id: string; name: string }; // Optional producer info
 }
 
-export default function CommentCard({ comment, currentUserId }: { comment: CommentData; currentUserId?: string; }) {
+export default function CommentCard({
+  comment,
+  currentUserId,
+  highlighted,
+}: {
+  comment: CommentData;
+  currentUserId?: string;
+  highlighted?: boolean;
+}) {
   const [editing, setEditing] = useState(false);
   const [text, setText] = useState(comment.text);
   const [images, setImages] = useState<string[]>(comment.imageUrls);
@@ -86,7 +95,7 @@ export default function CommentCard({ comment, currentUserId }: { comment: Comme
     <div className="bg-gray-50 rounded-lg p-4 mb-4 shadow">
       <div className="flex justify-between mb-2">
         <div>
-          <p className="font-semibold">{comment.user.name || comment.user.email}</p>
+          <p className={`font-semibold ${highlighted ? "text-blue-600" : ""}`}>{comment.user.name || comment.user.email}</p>
           <p className="text-xs text-gray-500">Last edited {new Date(comment.updatedAt).toLocaleString()}</p>
         </div>
         {currentUserId === comment.userId && (
@@ -95,6 +104,11 @@ export default function CommentCard({ comment, currentUserId }: { comment: Comme
           </button>
         )}
       </div>
+      {comment.producer && (
+        <p className="text-sm text-gray-700 mb-1">
+          For producer: <a href={`/producer/${comment.producer.id}`} className="underline hover:text-blue-600">{comment.producer.name}</a>
+        </p>
+      )}
       <p className="whitespace-pre-wrap mb-2">{comment.text}</p>
       <div className="flex flex-wrap gap-2">
         {images.map((url) => (


### PR DESCRIPTION
## Summary
- update `CommentCard` to accept optional producer info
- support highlighting a comment's author in blue
- show which producer a comment belongs to on the profile page
- highlight the logged-in user's comment on producer pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858eceb5264832d8844c67e617ac358