### PR TITLE
Fix rating display and supabase server client

### DIFF
--- a/src/app/producer/[id]/page.tsx
+++ b/src/app/producer/[id]/page.tsx
@@ -5,7 +5,7 @@ import { Category } from "@prisma/client"; // Import Category enum if needed for
 import CommentCard from "@/components/CommentCard";
 import AddCommentForm from "@/components/AddCommentForm";
 import VoteButton from "@/components/VoteButton";
-import { supabaseServer } from "@/lib/supabaseServer";
+import { createSupabaseServerClient } from "@/lib/supabaseServer";
 
 // Helper function to capitalize category
 const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
@@ -19,7 +19,7 @@ interface ProducerProfilePageProps {
 export default async function ProducerProfilePage({ params }: ProducerProfilePageProps) {
   const { id } = await params;
 
-  const supabase = supabaseServer;
+  const supabase = createSupabaseServerClient();
   const {
     data: { session },
   } = await supabase.auth.getSession();
@@ -130,7 +130,12 @@ export default async function ProducerProfilePage({ params }: ProducerProfilePag
               </div>
               <div className="flex items-center mb-2 sm:mb-0">
                 <span className="mr-2 font-semibold">Your Rating:</span>
-                <VoteButton producerId={id} initialAverage={averageRating} userRating={userVoteValue} />
+                <VoteButton
+                  producerId={id}
+                  initialAverage={averageRating}
+                  userRating={userVoteValue}
+                  showNumber={false}
+                />
               </div>
               {rank > 0 && (
                 <p className="text-gray-600">Rank: <span className="font-bold">#{rank}</span> <span className="text-sm">(in {producerCategoryFormatted})</span></p>

--- a/src/components/VoteButton.tsx
+++ b/src/components/VoteButton.tsx
@@ -12,12 +12,14 @@ export default function VoteButton({
   userRating,
   readOnly = false,
   navigateOnClick = false,
+  showNumber = true,
 }: {
   producerId: string;
   initialAverage: number;
   userRating: number | null | undefined;
   readOnly?: boolean;
   navigateOnClick?: boolean;
+  showNumber?: boolean;
 }) {
   const router = useRouter();
   const [session, setSession] = useState<Session | null>(null);
@@ -59,24 +61,31 @@ export default function VoteButton({
   return (
     <div className="flex items-center space-x-1">
       {[1, 2, 3, 4, 5].map((n) => {
-        const display = readOnly ? Math.round(initialAverage) : rating;
+        const display = readOnly ? initialAverage : rating;
+        const fraction = Math.max(0, Math.min(display - (n - 1), 1));
         return (
           <button
             key={n}
             onClick={() => cast(n)}
             className={`p-0.5 ${!readOnly || navigateOnClick ? "cursor-pointer" : ""}`}
           >
-            <Star
-              className={`w-5 h-5 ${
-                n <= display ? "text-yellow-400 fill-yellow-400" : "text-gray-400"
-              }`}
-            />
+            <div className="relative w-5 h-5">
+              <Star className="absolute w-5 h-5 text-gray-400" />
+              <div
+                className="absolute overflow-hidden top-0 left-0"
+                style={{ width: `${fraction * 100}%` }}
+              >
+                <Star className="w-5 h-5 text-yellow-400 fill-yellow-400" />
+              </div>
+            </div>
           </button>
         );
       })}
-      <span className="ml-2 text-sm text-gray-700">
-        {initialAverage.toFixed(1)}
-      </span>
+      {showNumber && (
+        <span className="ml-2 text-sm text-gray-700">
+          {initialAverage.toFixed(1)}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/lib/supabaseServer.ts
+++ b/src/lib/supabaseServer.ts
@@ -2,4 +2,5 @@
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 
-export const supabaseServer = createServerComponentClient({ cookies });
+export const createSupabaseServerClient = () =>
+  createServerComponentClient({ cookies });


### PR DESCRIPTION
## Summary
- create a server supabase client per request
- show fractional stars in `VoteButton`
- hide rating number in "Your Rating" section

## Testing
- `npm run lint` *(fails: prompts for eslint setup)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6858f1133678832d827b0e3fc73f8208