### PR TITLE
Fix admin verification logic

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -48,7 +48,16 @@ export default function AdminPage() {
       }
     };
 
-    fetchProducers();
+    const run = async () => {
+      const res = await fetch('/api/users/me');
+      const data = await res.json();
+      if (!data.success || data.role !== 'ADMIN') {
+        router.push('/');
+        return;
+      }
+      await fetchProducers();
+    };
+    run();
   }, []);
 
   const handleDelete = (producerId: string, producerName: string) => {

--- a/src/app/api/admin/create-producer/route.ts
+++ b/src/app/api/admin/create-producer/route.ts
@@ -1,8 +1,28 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prismadb";
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import { Role } from "@prisma/client";
 
 export async function POST(request: Request) {
+  const supabase = createServerActionClient({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+  });
+
+  if (!user || user.role !== Role.ADMIN) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
   const { name, category } = await request.json();
-  await prisma.producer.create({ data: { name, category } });
+  await prisma.producer.create({ data: { name, category, createdById: user.id } });
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -27,5 +27,5 @@ export async function GET() {
     );
   }
 
-  return NextResponse.json({ success: true, id: user.id });
+  return NextResponse.json({ success: true, id: user.id, role: user.role });
 }

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,9 +1,12 @@
 // src/app/api/users/route.ts
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prismadb";
+import { Role } from "@prisma/client";
 
 export async function POST(request: Request) {
   const { id, email, name } = await request.json();
+
+  const role = email === process.env.ADMIN_EMAIL ? Role.ADMIN : Role.USER;
 
   // Upsert a Prisma User record matching the Supabase user
   await prisma.user.upsert({
@@ -11,12 +14,13 @@ export async function POST(request: Request) {
     update: {
       email,
       name,
+      role,
     },
     create: {
       id,
       email,
       name,
-      // passwordHash and role default to null/USER
+      role,
     },
   });
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -46,7 +46,26 @@ function LoginForm() {
     } = await supabase.auth.getSession();
 
     if (session) {
-      router.push("/admin");
+      await fetch("/api/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: session.user.id,
+          email: session.user.email,
+          name: session.user.user_metadata?.name || session.user.email,
+        }),
+      });
+      const meRes = await fetch("/api/users/me");
+      const meData = await meRes.json();
+      if (meData.success) {
+        if (meData.role === "ADMIN") {
+          router.push("/admin");
+        } else {
+          router.push(`/profile/${meData.id}`);
+        }
+      } else {
+        router.push("/");
+      }
     } else {
       setError(finalError?.message ?? "Authentication failed");
     }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,6 +11,7 @@ export default function Navbar() {
   const pathname = usePathname();
   const [session, setSession] = useState<Session | null>(null);
   const [profileId, setProfileId] = useState<string | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     // fetch initial session
@@ -21,6 +22,7 @@ export default function Navbar() {
         const data = await res.json();
         if (data.success) {
           setProfileId(data.id);
+          setIsAdmin(data.role === "ADMIN");
         }
       }
     });
@@ -32,11 +34,14 @@ export default function Navbar() {
         const data = await res.json();
         if (data.success) {
           setProfileId(data.id);
+          setIsAdmin(data.role === "ADMIN");
         } else {
           setProfileId(null);
+          setIsAdmin(false);
         }
       } else {
         setProfileId(null);
+        setIsAdmin(false);
       }
     });
     return () => {
@@ -64,7 +69,7 @@ export default function Navbar() {
             </Link>
           )}
 
-          {session && (
+          {session && isAdmin && (
             <Link
               href="/admin"
               className={`${pathname === "/admin" ? "underline" : ""} cursor-pointer`}


### PR DESCRIPTION
## Summary
- ensure user role is set on login via `/api/users`
- include user role in `/api/users/me`
- only show admin link to admins in navbar
- redirect based on role after login
- restrict admin page and create-producer API

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: interactive prompt)*


------
https://chatgpt.com/codex/tasks/task_e_6858f50ce630832d9cc070134652cf97