### PR TITLE
Fix env var usage for Supabase

### DIFF
--- a/src/app/api/admin/create-producer/route.ts
+++ b/src/app/api/admin/create-producer/route.ts
@@ -8,8 +8,7 @@ const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUP
 import { Role } from "@prisma/client";
 
 export async function POST(request: Request) {
-  const supabase = createServerActionClient({
-    cookies,
+  const supabase = createServerActionClient({ cookies }, {
     supabaseUrl,
     supabaseKey,
   });

--- a/src/app/api/admin/create-producer/route.ts
+++ b/src/app/api/admin/create-producer/route.ts
@@ -2,10 +2,17 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prismadb";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
 import { Role } from "@prisma/client";
 
 export async function POST(request: Request) {
-  const supabase = createServerActionClient({ cookies });
+  const supabase = createServerActionClient({
+    cookies,
+    supabaseUrl,
+    supabaseKey,
+  });
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/src/app/api/producers/[id]/route.ts
+++ b/src/app/api/producers/[id]/route.ts
@@ -14,8 +14,7 @@ export async function DELETE(
 ) {
   try {
     // 1. Authentication & Authorization
-    const supabase = createServerActionClient({
-      cookies,
+    const supabase = createServerActionClient({ cookies }, {
       supabaseUrl,
       supabaseKey,
     });

--- a/src/app/api/producers/[id]/route.ts
+++ b/src/app/api/producers/[id]/route.ts
@@ -3,6 +3,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prismadb";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs"; // Correct import for Route Handlers
 import { cookies } from "next/headers";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
 import { Role } from "@prisma/client";
 
 export async function DELETE(
@@ -11,7 +14,11 @@ export async function DELETE(
 ) {
   try {
     // 1. Authentication & Authorization
-    const supabase = createServerActionClient({ cookies }); // Use createServerActionClient for Route Handlers
+    const supabase = createServerActionClient({
+      cookies,
+      supabaseUrl,
+      supabaseKey,
+    });
     const {
       data: { session },
     } = await supabase.auth.getSession();

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -7,8 +7,7 @@ const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
 
 export async function GET() {
-  const supabase = createServerActionClient({
-    cookies,
+  const supabase = createServerActionClient({ cookies }, {
     supabaseUrl,
     supabaseKey,
   });

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -3,8 +3,15 @@ import { prisma } from "@/lib/prismadb";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
 export async function GET() {
-  const supabase = createServerActionClient({ cookies });
+  const supabase = createServerActionClient({
+    cookies,
+    supabaseUrl,
+    supabaseKey,
+  });
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,8 +1,14 @@
 // src/lib/supabaseClient.ts
 import { createPagesBrowserClient } from "@supabase/auth-helpers-nextjs";
 
-console.log('🌐 Supabase URL:', process.env.NEXT_PUBLIC_SUPABASE_URL);
-console.log('🔑 Anon key present?', Boolean(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY));
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
 
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error("Supabase environment variables are missing");
+}
 
-export const supabase = createPagesBrowserClient();
+export const supabase = createPagesBrowserClient({
+  supabaseUrl,
+  supabaseKey,
+});

--- a/src/lib/supabaseServer.ts
+++ b/src/lib/supabaseServer.ts
@@ -10,8 +10,7 @@ if (!supabaseUrl || !supabaseKey) {
 }
 
 export const createSupabaseServerClient = () =>
-  createServerComponentClient({
-    cookies,
+  createServerComponentClient({ cookies }, {
     supabaseUrl,
     supabaseKey,
   });

--- a/src/lib/supabaseServer.ts
+++ b/src/lib/supabaseServer.ts
@@ -2,5 +2,16 @@
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error("Supabase environment variables are missing");
+}
+
 export const createSupabaseServerClient = () =>
-  createServerComponentClient({ cookies });
+  createServerComponentClient({
+    cookies,
+    supabaseUrl,
+    supabaseKey,
+  });


### PR DESCRIPTION
## Summary
- explicitly provide Supabase env variables when creating clients
- ensure server and API handlers use environment values

## Testing
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6858fe5e6444832d8ffd6e4c326b847f