### PR TITLE
Add admin role helper and debugging logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "next start",
     "lint": "next lint",
     "db:seed": "prisma db seed",
-    "migrate:reset": "prisma migrate reset --force"
+    "migrate:reset": "prisma migrate reset --force",
+    "test": "node -r ts-node/register --test tests/role.test.js"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -26,6 +26,8 @@ export async function GET() {
     where: { email: session.user.email },
   });
 
+  console.log("[GET /api/users/me] session email", session.user.email, "user", user);
+
   if (!user) {
     return NextResponse.json(
       { success: false, error: "User not found" },

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,12 +1,13 @@
 // src/app/api/users/route.ts
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prismadb";
-import { Role } from "@prisma/client";
+import { getRoleForEmail } from "@/utils/role";
 
 export async function POST(request: Request) {
   const { id, email, name } = await request.json();
 
-  const role = email === process.env.ADMIN_EMAIL ? Role.ADMIN : Role.USER;
+  const role = getRoleForEmail(email);
+  console.log("[POST /api/users] email", email, "role", role);
 
   // Upsert a Prisma User record matching the Supabase user
   await prisma.user.upsert({

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -16,10 +16,12 @@ export default function Navbar() {
   useEffect(() => {
     // fetch initial session
     supabase.auth.getSession().then(async ({ data: { session } }) => {
+      console.log("[Navbar] initial session", session);
       setSession(session);
       if (session?.user?.email) {
         const res = await fetch("/api/users/me");
         const data = await res.json();
+        console.log("[Navbar] /api/users/me", data);
         if (data.success) {
           setProfileId(data.id);
           setIsAdmin(data.role === "ADMIN");
@@ -28,10 +30,12 @@ export default function Navbar() {
     });
     // listen for changes (login/logout)
     const { data: listener } = supabase.auth.onAuthStateChange(async (_event, sess) => {
+      console.log("[Navbar] auth state change", sess);
       setSession(sess);
       if (sess?.user?.email) {
         const res = await fetch("/api/users/me");
         const data = await res.json();
+        console.log("[Navbar] /api/users/me", data);
         if (data.success) {
           setProfileId(data.id);
           setIsAdmin(data.role === "ADMIN");

--- a/src/utils/role.ts
+++ b/src/utils/role.ts
@@ -1,0 +1,7 @@
+import { Role } from "@prisma/client";
+
+export function getRoleForEmail(email: string): Role {
+  const adminEmail = process.env.ADMIN_EMAIL;
+  console.log("[getRoleForEmail] adminEmail", adminEmail, "input email", email);
+  return email === adminEmail ? Role.ADMIN : Role.USER;
+}

--- a/tests/role.test.js
+++ b/tests/role.test.js
@@ -1,0 +1,14 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+require('ts-node/register');
+const { getRoleForEmail } = require('../src/utils/role.ts');
+
+test('returns ADMIN for admin email', () => {
+  process.env.ADMIN_EMAIL = 'admin@example.com';
+  assert.equal(getRoleForEmail('admin@example.com'), 'ADMIN');
+});
+
+test('returns USER for non-admin email', () => {
+  process.env.ADMIN_EMAIL = 'admin@example.com';
+  assert.equal(getRoleForEmail('user@example.com'), 'USER');
+});


### PR DESCRIPTION
## Summary
- centralize role detection with `getRoleForEmail`
- add console debug logs when loading session data
- log user info in `/api/users/me`
- remove redundant sample tests

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_685989c19e90832db83beb5bfa89faea