### PR TITLE
Show user rating on comments

### DIFF
--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import VoteButton from "@/components/VoteButton";
 
 export interface CommentData {
   id: string;
@@ -12,6 +13,7 @@ export interface CommentData {
   producerId: string;
   updatedAt: string | Date;
   producer?: { id: string; name: string }; // Optional producer info
+  voteValue?: number | null;
 }
 
 export default function CommentCard({
@@ -107,6 +109,19 @@ export default function CommentCard({
           For producer: <a href={`/producer/${comment.producer.id}`} className="underline hover:text-blue-600">{comment.producer.name}</a>
         </p>
       )}
+      <div className="mb-2">
+        {comment.voteValue !== null && comment.voteValue !== undefined ? (
+          <VoteButton
+            producerId={comment.producerId}
+            initialAverage={comment.voteValue}
+            userRating={comment.voteValue}
+            readOnly
+            showNumber={false}
+          />
+        ) : (
+          <span className="italic text-sm text-gray-600">No rating</span>
+        )}
+      </div>
       <p className="whitespace-pre-wrap mb-2">{comment.text}</p>
       <div className="flex flex-wrap gap-2">
         {images.map((url) => (


### PR DESCRIPTION
## Summary
- extend `CommentCard` to show the author’s star rating for that producer
- pull each commenter’s vote on producer pages and pass it into comment cards

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: missing Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_685a340f11b0832daf2d99b10d52c927