### PR TITLE
Fix signup flow and username routing

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -6,11 +6,19 @@ import { Role } from "@prisma/client";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const email = searchParams.get("email");
-  if (!email) {
-    return NextResponse.json({ exists: false });
+  const username = searchParams.get("username");
+
+  if (email) {
+    const user = await prisma.user.findUnique({ where: { email } });
+    return NextResponse.json({ exists: Boolean(user) });
   }
-  const user = await prisma.user.findUnique({ where: { email } });
-  return NextResponse.json({ exists: Boolean(user) });
+
+  if (username) {
+    const user = await prisma.user.findUnique({ where: { username } });
+    return NextResponse.json({ exists: Boolean(user) });
+  }
+
+  return NextResponse.json({ exists: false });
 }
 
 export async function POST(request: Request) {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -37,7 +37,7 @@ function LoginForm() {
         if (meData.role === "ADMIN") {
           router.push("/admin");
         } else {
-          router.push(`/profile/${meData.id}`);
+          router.push(`/profile/${meData.username || meData.id}`);
         }
       } else {
         router.push("/");

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,7 +11,7 @@ import type { Session } from "@supabase/supabase-js";
 export default function Navbar() {
   const pathname = usePathname();
   const [session, setSession] = useState<Session | null>(null);
-  const [profileId, setProfileId] = useState<string | null>(null);
+  const [profileUsername, setProfileUsername] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
@@ -22,7 +22,7 @@ export default function Navbar() {
         const res = await fetch("/api/users/me");
         const data = await res.json();
         if (data.success) {
-          setProfileId(data.id);
+          setProfileUsername(data.username || data.id);
           setIsAdmin(data.role === "ADMIN");
         }
       }
@@ -35,14 +35,14 @@ export default function Navbar() {
           const res = await fetch("/api/users/me");
           const data = await res.json();
           if (data.success) {
-            setProfileId(data.id);
+            setProfileUsername(data.username || data.id);
             setIsAdmin(data.role === "ADMIN");
           } else {
-            setProfileId(null);
+            setProfileUsername(null);
             setIsAdmin(false);
           }
         } else {
-          setProfileId(null);
+          setProfileUsername(null);
           setIsAdmin(false);
         }
       }
@@ -72,11 +72,11 @@ export default function Navbar() {
             Home
           </Link>
 
-          {profileId && (
+          {profileUsername && (
             <Link
-              href={`/profile/${profileId}`}
+              href={`/profile/${profileUsername}`}
               className={`${
-                pathname === `/profile/${profileId}`
+                pathname === `/profile/${profileUsername}`
                   ? "underline"
                   : "hover:underline"
               }`}


### PR DESCRIPTION
## Summary
- check usernames in `/api/users` and allow looking up by username
- enforce required username and improve signup form for password managers
- save user data immediately after signup
- update navbar and login redirect to use username-based profiles
- allow profile route to load by username or id

## Testing
- `npm run build` *(fails: Supabase environment variables are missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c248d86bc832db41bd198cb269ae1