### PR TITLE
Improve image upload UX

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
+import UploadButton from "@/components/UploadButton";
 
 export default function SignUpPage() {
   const router = useRouter();
@@ -223,12 +224,7 @@ export default function SignUpPage() {
           </div>
           <div>
             <label className="block">Profile Picture</label>
-            <input
-              type="file"
-              accept="image/*"
-              onChange={handleFileChange}
-              className="mt-1"
-            />
+            <UploadButton onChange={handleFileChange} className="mt-1" />
             {uploading && <p className="text-sm text-gray-500">Uploading...</p>}
             {uploadUrl && (
               // eslint-disable-next-line @next/next/no-img-element

--- a/src/components/AddCommentForm.tsx
+++ b/src/components/AddCommentForm.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { supabase } from "@/lib/supabaseClient";
 import { useRouter } from "next/navigation";
+import UploadButton from "./UploadButton";
 
 export default function AddCommentForm({ producerId }: { producerId: string }) {
   const [text, setText] = useState("");
@@ -51,7 +52,7 @@ export default function AddCommentForm({ producerId }: { producerId: string }) {
         className="w-full border rounded-md p-2"
         placeholder="Leave a comment"
       />
-      <input type="file" multiple onChange={handleFileChange} />
+      <UploadButton multiple onChange={handleFileChange} />
       <button
         onClick={submit}
         className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded-md"

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import VoteButton from "@/components/VoteButton";
+import UploadButton from "./UploadButton";
 
 export interface CommentData {
   id: string;
@@ -87,7 +88,7 @@ export default function CommentCard({
             </div>
           ))}
         </div>
-        <input type="file" multiple onChange={handleFileChange} className="mb-3" />
+        <UploadButton multiple onChange={handleFileChange} className="mb-3" />
         <button onClick={save} className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded-md">Save</button>
       </div>
     );

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import UploadButton from "./UploadButton";
 
 export default function ImageUpload({ value, onChange }: { value: string | null; onChange: (url: string | null) => void }) {
   const [loading, setLoading] = useState(false);
@@ -34,7 +35,7 @@ export default function ImageUpload({ value, onChange }: { value: string | null;
           </button>
         </div>
       ) : (
-        <input type="file" accept="image/*" onChange={handleChange} />
+        <UploadButton onChange={handleChange} />
       )}
       {loading && <span className="text-sm animate-pulse">Uploading...</span>}
     </div>

--- a/src/components/UploadButton.tsx
+++ b/src/components/UploadButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { useId } from "react";
+import { Upload } from "lucide-react";
+
+export default function UploadButton({
+  onChange,
+  multiple = false,
+  label = "Upload",
+  className = "",
+}: {
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  multiple?: boolean;
+  label?: string;
+  className?: string;
+}) {
+  const id = useId();
+  return (
+    <label
+      htmlFor={id}
+      className={`inline-flex items-center space-x-1 bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded-md cursor-pointer ${className}`}
+    >
+      <Upload className="w-4 h-4" />
+      <span>{label}</span>
+      <input
+        id={id}
+        type="file"
+        accept="image/*"
+        multiple={multiple}
+        onChange={onChange}
+        className="hidden"
+      />
+    </label>
+  );
+}


### PR DESCRIPTION
## Summary
- add `UploadButton` component for consistent styling
- refactor existing forms to use the new button
- improve comment card and sign up form upload UX
- use Lucide upload icon

## Testing
- `npm run build` *(fails: Supabase environment variables are missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f7ad1c964832d8ccda90f93c5b225