### PR TITLE
Improve mobile navigation and comments

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import AddProducerForm from "@/components/AddProducerForm";
 import Modal from "@/components/Modal";
 import type { Producer } from "@prisma/client";
-import { XCircle } from "lucide-react";
+import { XCircle, FilePenLine } from "lucide-react";
 
 export default function AdminPage() {
   const router = useRouter();
@@ -140,8 +140,9 @@ export default function AdminPage() {
                     <button
                       onClick={() => handleEdit(p)}
                       className="text-blue-600 hover:text-blue-800"
+                      aria-label={`Edit ${p.name || 'this producer'}`}
                     >
-                      Edit
+                      <FilePenLine size={20} />
                     </button>
                     <button
                       onClick={() => handleDelete(p.id, p.name || 'this producer')}

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -93,7 +93,7 @@ export async function DELETE(request: NextRequest) {
     data: { session },
   } = await supabase.auth.getSession();
 
-  if (!session?.user?.id) {
+  if (!session?.user?.email) {
     return NextResponse.json(
       { success: false, error: "Not authenticated" },
       { status: 401 }
@@ -109,8 +109,19 @@ export async function DELETE(request: NextRequest) {
     );
   }
 
+  const prismaUser = await prisma.user.findUnique({
+    where: { email: session.user.email },
+  });
+
+  if (!prismaUser) {
+    return NextResponse.json(
+      { success: false, error: "User not found" },
+      { status: 404 }
+    );
+  }
+
   const comment = await prisma.comment.findUnique({ where: { id } });
-  if (!comment || comment.userId !== session.user.id) {
+  if (!comment || comment.userId !== prismaUser.id) {
     return NextResponse.json(
       { success: false, error: "Not authorized" },
       { status: 403 }

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -51,17 +51,17 @@ export async function PATCH(request: Request) {
     data: { session },
   } = await supabase.auth.getSession();
 
-  if (!session?.user?.id) {
-    return NextResponse.json(
-      { success: false, error: "Not authenticated" },
-      { status: 401 },
-    );
+  if (!session?.user?.email) {
+      return NextResponse.json(
+        { success: false, error: "Not authenticated" },
+        { status: 401 },
+      );
   }
 
   const { profilePicUrl } = await request.json();
 
   await prisma.user.update({
-    where: { id: session.user.id },
+    where: { email: session.user.email },
     data: { profilePicUrl },
   });
 

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -28,10 +28,10 @@ export async function POST(request: Request) {
   const role = email === process.env.ADMIN_EMAIL ? Role.ADMIN : Role.USER;
 
   // Upsert a Prisma User record matching the Supabase user
+  // Use email as the unique key to support existing accounts
   await prisma.user.upsert({
-    where: { id },
+    where: { email },
     update: {
-      email,
       name,
       username,
       birthday: birthday ? new Date(birthday) : undefined,

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -106,7 +106,7 @@ function LoginForm() {
       <button
         onClick={handleSignIn}
         disabled={loading}
-        className={`w-full py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition duration-150 ${loading ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+        className={`w-full py-2.5 bg-green-600 hover:bg-green-700 text-white rounded-md transition duration-150 ${loading ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
       >
         Log In
       </button>

--- a/src/app/producer/[slug]/page.tsx
+++ b/src/app/producer/[slug]/page.tsx
@@ -115,11 +115,11 @@ export default async function ProducerProfilePage({
   const producerCategoryFormatted = capitalize(producer.category);
 
   return (
-    <div className="container mx-auto p-4 mt-8">
-      <div className="bg-white shadow-xl rounded-lg p-6 md:p-8 max-w-3xl mx-auto">
+    <div className="container mx-auto p-4">
+      <div className="bg-white shadow-xl rounded-lg p-6 md:p-8 max-w-3xl mx-auto relative">
         <div className="flex flex-col md:flex-row items-start md:items-center mb-6 pb-6 border-b border-gray-300">
           {(producer.profileImage || producer.logoUrl) && (
-            <div className="relative w-24 h-24 md:w-32 md:h-32 mr-0 md:mr-6 mb-4 md:mb-0 rounded-lg overflow-hidden flex-shrink-0 bg-gray-100">
+            <div className="w-24 h-24 md:w-32 md:h-32 mr-0 md:mr-6 mb-4 md:mb-0 rounded-lg overflow-hidden flex-shrink-0 bg-gray-100 relative">
               <Image
                 src={producer.profileImage || producer.logoUrl!}
                 alt={`${producer.name} logo`}
@@ -129,11 +129,11 @@ export default async function ProducerProfilePage({
             </div>
           )}
           <div className="flex-grow text-center md:text-left">
-            <div className="flex items-center mb-2 relative">
+            <div className="flex items-center mb-2">
               <h1 className="text-3xl md:text-4xl font-bold text-gray-800">
                 {producer.name}
               </h1>
-              <div className="flex items-center space-x-2 absolute right-0 top-0 sm:static">
+              <div className="flex items-center space-x-4 absolute right-6 top-6">
                 {producer.website && (
                   <a
                     href={producer.website}
@@ -142,7 +142,7 @@ export default async function ProducerProfilePage({
                     className="text-blue-600"
                     aria-label="Website"
                   >
-                    <ExternalLink className="w-5 h-5" />
+                    <ExternalLink className="w-6 h-6" />
                   </a>
                 )}
                 {producer.ingredients && (
@@ -174,12 +174,12 @@ export default async function ProducerProfilePage({
             />
           </div>
           <div className="flex items-center mb-2 sm:mb-0">
-            <span className="mr-2 font-semibold">Your Rating:</span>
+            <span className="mr-1.5 font-semibold">Your Rating:</span>
             <VoteButton
               producerId={producer.id}
               initialAverage={averageRating}
               userRating={userVoteValue}
-              showNumber={false}
+              showNumber={true}
             />
           </div>
         </div>

--- a/src/app/producer/[slug]/page.tsx
+++ b/src/app/producer/[slug]/page.tsx
@@ -129,11 +129,11 @@ export default async function ProducerProfilePage({
             </div>
           )}
           <div className="flex-grow text-center md:text-left">
-            <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center mb-2 relative">
               <h1 className="text-3xl md:text-4xl font-bold text-gray-800">
                 {producer.name}
               </h1>
-              <div className="flex items-center space-x-2">
+              <div className="flex items-center space-x-2 absolute right-0 top-0 sm:static">
                 {producer.website && (
                   <a
                     href={producer.website}

--- a/src/app/producer/[slug]/page.tsx
+++ b/src/app/producer/[slug]/page.tsx
@@ -129,16 +129,26 @@ export default async function ProducerProfilePage({
             </div>
           )}
           <div className="flex-grow text-center md:text-left">
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-start mb-2 space-x-2">
-              <h1 className="text-3xl md:text-4xl font-bold text-gray-800 mb-2 sm:mb-0">
+            <div className="flex items-center justify-between mb-2">
+              <h1 className="text-3xl md:text-4xl font-bold text-gray-800">
                 {producer.name}
               </h1>
-              {producer.website && (
-                <a href={producer.website} target="_blank" rel="noopener noreferrer" className="text-blue-600" aria-label="Website">
-                  <ExternalLink className="w-5 h-5" />
-                </a>
-              )}
-              {producer.ingredients && <IngredientsButton ingredients={producer.ingredients} />}
+              <div className="flex items-center space-x-2">
+                {producer.website && (
+                  <a
+                    href={producer.website}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600"
+                    aria-label="Website"
+                  >
+                    <ExternalLink className="w-5 h-5" />
+                  </a>
+                )}
+                {producer.ingredients && (
+                  <IngredientsButton ingredients={producer.ingredients} />
+                )}
+              </div>
             </div>
             {rank > 0 && (
               <p className="text-gray-600 mt-4">

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -57,7 +57,7 @@ export default async function ProfilePage({
     return <p>User not found. ({id})</p>;
   }
 
-  const isOwner = session?.user?.id === user.id;
+  const isOwner = session?.user?.email === user.email;
 
   // Process votes into liked and disliked producers
   const likedProducers = user.votes

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -159,7 +159,7 @@ export default function SignUpPage() {
           <button
             onClick={checkEmail}
             disabled={loading}
-            className="w-full py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-md"
+            className="w-full py-2.5 bg-green-600 hover:bg-green-700 text-white rounded-md"
           >
             Continue
           </button>
@@ -281,7 +281,7 @@ export default function SignUpPage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-md"
+            className="w-full py-2.5 bg-green-600 hover:bg-green-700 text-white rounded-md"
           >
             Submit
           </button>

--- a/src/components/AddCommentForm.tsx
+++ b/src/components/AddCommentForm.tsx
@@ -1,17 +1,29 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabaseClient";
 import { useRouter } from "next/navigation";
 import UploadButton from "./UploadButton";
+import type { Session } from "@supabase/supabase-js";
 
 export default function AddCommentForm({ producerId }: { producerId: string }) {
   const [text, setText] = useState("");
   const [files, setFiles] = useState<File[]>([]);
+  const [session, setSession] = useState<Session | null>(null);
   const router = useRouter();
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) setFiles(Array.from(e.target.files));
   };
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+    const { data: listener } = supabase.auth.onAuthStateChange((_e, sess) =>
+      setSession(sess)
+    );
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, []);
 
   const uploadFiles = async () => {
     const uploaded: string[] = [];
@@ -26,9 +38,6 @@ export default function AddCommentForm({ producerId }: { producerId: string }) {
   };
 
   const submit = async () => {
-    const {
-      data: { session },
-    } = await supabase.auth.getSession();
     if (!session?.user) {
       router.push("/login?reason=comment");
       return;
@@ -52,7 +61,14 @@ export default function AddCommentForm({ producerId }: { producerId: string }) {
         className="w-full border rounded-md p-2"
         placeholder="Leave a comment"
       />
-      <UploadButton multiple onChange={handleFileChange} />
+      <UploadButton
+        multiple
+        onChange={handleFileChange}
+        disabled={!session?.user}
+        onClick={() => {
+          if (!session?.user) router.push("/login?reason=comment");
+        }}
+      />
       <button
         onClick={submit}
         className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded-md"

--- a/src/components/AddCommentForm.tsx
+++ b/src/components/AddCommentForm.tsx
@@ -71,7 +71,7 @@ export default function AddCommentForm({ producerId }: { producerId: string }) {
       />
       <button
         onClick={submit}
-        className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded-md"
+        className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded-md"
       >
         Submit
       </button>

--- a/src/components/AddCommentForm.tsx
+++ b/src/components/AddCommentForm.tsx
@@ -54,7 +54,7 @@ export default function AddCommentForm({ producerId }: { producerId: string }) {
   };
 
   return (
-    <div className="bg-white shadow rounded-lg p-4 mb-6 space-y-3">
+    <div className="bg-white shadow rounded-lg p-4 mb-6">
       <textarea
         value={text}
         onChange={(e) => setText(e.target.value)}
@@ -71,7 +71,7 @@ export default function AddCommentForm({ producerId }: { producerId: string }) {
       />
       <button
         onClick={submit}
-        className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded-md"
+        className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 ml-2 rounded-md"
       >
         Submit
       </button>

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -2,6 +2,8 @@
 import { useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Leaf } from "lucide-react";
 import VoteButton from "@/components/VoteButton";
 import UploadButton from "./UploadButton";
 
@@ -9,11 +11,17 @@ export interface CommentData {
   id: string;
   text: string;
   imageUrls: string[];
-  user: { id: string; name: string | null; email: string };
+  user: {
+    id: string;
+    name: string | null;
+    email: string;
+    username: string | null;
+    profilePicUrl: string | null;
+  };
   userId: string;
   producerId: string;
   updatedAt: string | Date;
-  producer?: { id: string; name: string; slug: string | null }; // Optional producer info
+  producer?: { id: string; name: string; slug: string | null };
   voteValue?: number | null;
 }
 
@@ -63,6 +71,11 @@ export default function CommentCard({
     setImages((prev) => prev.filter((u) => u !== url));
   };
 
+  const deleteComment = async () => {
+    await fetch(`/api/comments?id=${comment.id}`, { method: "DELETE" });
+    router.refresh();
+  };
+
   if (editing) {
     return (
       <div className="bg-white shadow rounded-lg p-4 mb-4">
@@ -94,14 +107,40 @@ export default function CommentCard({
   return (
     <div className="bg-gray-50 rounded-lg p-4 mb-4 shadow">
       <div className="flex justify-between mb-2">
-        <div>
-          <p className={`font-semibold ${highlighted ? "text-blue-600" : ""}`}>{comment.user.name || comment.user.email}</p>
-          <p className="text-xs text-gray-500">Last edited {new Date(comment.updatedAt).toLocaleString()}</p>
+        <div className="flex items-center">
+          {comment.user.profilePicUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={comment.user.profilePicUrl}
+              alt="profile"
+              className="w-10 h-10 rounded-full object-cover"
+            />
+          ) : (
+            <div className="w-10 h-10 rounded-full bg-gray-300 flex items-center justify-center">
+              <Leaf className="w-5 h-5 text-white" />
+            </div>
+          )}
+          <div className="ml-2">
+            <Link
+              href={`/profile/${comment.user.username ?? comment.user.id}`}
+              className={`font-semibold ${highlighted ? "text-blue-600" : "hover:underline"}`}
+            >
+              {comment.user.username || comment.user.name || comment.user.email}
+            </Link>
+            <p className="text-xs text-gray-500">
+              Last edited {new Date(comment.updatedAt).toLocaleString()}
+            </p>
+          </div>
         </div>
         {currentUserId === comment.userId && (
-          <button onClick={() => setEditing(true)} className="text-sm text-blue-600 hover:underline">
-            Edit
-          </button>
+          <div className="flex items-center space-x-2">
+            <button onClick={() => setEditing(true)} className="text-sm text-blue-600 hover:underline">
+              Edit
+            </button>
+            <button onClick={deleteComment} className="text-sm text-red-600 hover:underline">
+              Delete
+            </button>
+          </div>
         )}
       </div>
       {comment.producer && (

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -85,7 +85,7 @@ export default function CommentCard({
         <textarea
           value={text}
           onChange={(e) => setText(e.target.value)}
-          className="w-full border rounded-md p-2 mb-3"
+          className="w-full border rounded-md p-2"
         />
         <div className="flex flex-wrap gap-2 mb-3">
           {images.map((url) => (
@@ -93,16 +93,16 @@ export default function CommentCard({
               <img src={url} className="w-20 h-20 object-cover rounded" />
               <button
                 onClick={() => removeImage(url)}
-                className="absolute -top-1 -right-1 bg-white rounded-full text-xs px-1 cursor-pointer border"
+                className="absolute -top-1 -right-1 bg-white rounded-full text-xs px-1.25 cursor-pointer border"
               >
                 x
               </button>
             </div>
           ))}
         </div>
-        <UploadButton multiple onChange={handleFileChange} className="mb-3" />
+        <UploadButton multiple onChange={handleFileChange}/>
         {uploading && <p className="text-sm text-gray-500 mb-3">Uploading...</p>}
-        <button onClick={save} className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded-md">Save</button>
+        <button onClick={save} className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded-md ml-2">Save</button>
       </div>
     );
   }
@@ -126,7 +126,7 @@ export default function CommentCard({
           <div className="ml-2">
             <Link
               href={`/profile/${comment.user.username ?? comment.user.id}`}
-              className={`font-semibold ${highlighted ? "text-blue-600" : "hover:underline"}`}
+              className={`font-semibold ${highlighted ? "text-green-600" : "hover:underline"}`}
             >
               {comment.user.username || comment.user.name || comment.user.email}
             </Link>

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Leaf } from "lucide-react";
+import { Leaf, Trash2, FilePenLine } from "lucide-react";
 import VoteButton from "@/components/VoteButton";
 import UploadButton from "./UploadButton";
 
@@ -72,7 +72,10 @@ export default function CommentCard({
   };
 
   const deleteComment = async () => {
-    await fetch(`/api/comments?id=${comment.id}`, { method: "DELETE" });
+    await fetch(`/api/comments?id=${comment.id}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
     router.refresh();
   };
 
@@ -134,11 +137,19 @@ export default function CommentCard({
         </div>
         {currentUserId === comment.userId && (
           <div className="flex items-center space-x-2">
-            <button onClick={() => setEditing(true)} className="text-sm text-blue-600 hover:underline">
-              Edit
+            <button
+              onClick={() => setEditing(true)}
+              className="text-blue-600 hover:text-blue-800"
+              aria-label="Edit comment"
+            >
+              <FilePenLine className="w-4 h-4" />
             </button>
-            <button onClick={deleteComment} className="text-sm text-red-600 hover:underline">
-              Delete
+            <button
+              onClick={deleteComment}
+              className="text-red-600 hover:text-red-800"
+              aria-label="Delete comment"
+            >
+              <Trash2 className="w-4 h-4" />
             </button>
           </div>
         )}

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -102,7 +102,7 @@ export default function CommentCard({
         </div>
         <UploadButton multiple onChange={handleFileChange} className="mb-3" />
         {uploading && <p className="text-sm text-gray-500 mb-3">Uploading...</p>}
-        <button onClick={save} className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded-md">Save</button>
+        <button onClick={save} className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded-md">Save</button>
       </div>
     );
   }

--- a/src/components/IngredientsButton.tsx
+++ b/src/components/IngredientsButton.tsx
@@ -9,7 +9,7 @@ export default function IngredientsButton({ ingredients }: { ingredients: string
     <>
       <button
         onClick={() => setOpen(true)}
-        className="flex items-center text-blue-600 hover:text-blue-800"
+        className="flex items-center text-blue-600 hover:text-blue-800 cursor-pointer"
         aria-label="Ingredients"
       >
         <Info className="w-5 h-5" />

--- a/src/components/IngredientsButton.tsx
+++ b/src/components/IngredientsButton.tsx
@@ -12,7 +12,7 @@ export default function IngredientsButton({ ingredients }: { ingredients: string
         className="flex items-center text-blue-600 hover:text-blue-800 cursor-pointer"
         aria-label="Ingredients"
       >
-        <Info className="w-5 h-5" />
+        <Info className="w-6 h-6" />
       </button>
       <Modal isOpen={open} onClose={() => setOpen(false)}>
         <p className="whitespace-pre-wrap text-sm">{ingredients}</p>

--- a/src/components/IngredientsButton.tsx
+++ b/src/components/IngredientsButton.tsx
@@ -9,12 +9,13 @@ export default function IngredientsButton({ ingredients }: { ingredients: string
     <>
       <button
         onClick={() => setOpen(true)}
-        className="flex items-center text-sm text-blue-600 hover:underline"
+        className="flex items-center text-blue-600 hover:text-blue-800"
+        aria-label="Ingredients"
       >
-        <Info className="w-4 h-4 mr-1" /> Ingredients
+        <Info className="w-5 h-5" />
       </button>
       <Modal isOpen={open} onClose={() => setOpen(false)}>
-        <p className="whitespace-pre-wrap">{ingredients}</p>
+        <p className="whitespace-pre-wrap text-sm">{ingredients}</p>
       </Modal>
     </>
   );

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -11,7 +11,7 @@ export default function Modal({ isOpen, onClose, children }: ModalProps) {
   if (!isOpen) return null;
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 px-2">
-      <div className="bg-white rounded-lg shadow-lg p-6 w-full max-w-md relative">
+      <div className="bg-white rounded-lg shadow-lg p-6 w-full max-w-md relative overflow-y-auto max-h-[80vh]">
         <button
           onClick={onClose}
           className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -10,17 +10,15 @@ interface ModalProps {
 export default function Modal({ isOpen, onClose, children }: ModalProps) {
   if (!isOpen) return null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white rounded shadow-lg p-4 max-w-sm w-full">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 px-2">
+      <div className="bg-white rounded-lg shadow-lg p-6 w-full max-w-md relative">
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+        >
+          ✕
+        </button>
         {children}
-        <div className="mt-4 text-right">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300 cursor-pointer"
-          >
-            Close
-          </button>
-        </div>
       </div>
     </div>
   );

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -11,7 +11,7 @@ export default function Modal({ isOpen, onClose, children }: ModalProps) {
   if (!isOpen) return null;
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 px-2">
-      <div className="bg-white rounded-lg shadow-lg p-6 w-full max-w-md relative overflow-y-auto max-h-[80vh]">
+      <div className="bg-white rounded-lg shadow-lg p-4 sm:p-6 w-full max-w-sm sm:max-w-md relative overflow-y-auto max-h-[80vh]">
         <button
           onClick={onClose}
           className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -20,11 +20,17 @@ export default function Navbar() {
     supabase.auth.getSession().then(async ({ data: { session } }) => {
       setSession(session);
       if (session?.user?.email) {
-        const res = await fetch("/api/users/me");
-        const data = await res.json();
-        if (data.success) {
-          setProfileUsername(data.username || data.id);
-          setIsAdmin(data.role === "ADMIN");
+        try {
+          const res = await fetch("/api/users/me");
+          if (res.ok) {
+            const data = await res.json();
+            if (data.success) {
+              setProfileUsername(data.username || data.id);
+              setIsAdmin(data.role === "ADMIN");
+            }
+          }
+        } catch (err) {
+          console.error("Failed to fetch user", err);
         }
       }
     });
@@ -33,12 +39,23 @@ export default function Navbar() {
       async (_event, sess) => {
         setSession(sess);
         if (sess?.user?.email) {
-          const res = await fetch("/api/users/me");
-          const data = await res.json();
-          if (data.success) {
-            setProfileUsername(data.username || data.id);
-            setIsAdmin(data.role === "ADMIN");
-          } else {
+          try {
+            const res = await fetch("/api/users/me");
+            if (res.ok) {
+              const data = await res.json();
+              if (data.success) {
+                setProfileUsername(data.username || data.id);
+                setIsAdmin(data.role === "ADMIN");
+              } else {
+                setProfileUsername(null);
+                setIsAdmin(false);
+              }
+            } else {
+              setProfileUsername(null);
+              setIsAdmin(false);
+            }
+          } catch (err) {
+            console.error("Failed to fetch user", err);
             setProfileUsername(null);
             setIsAdmin(false);
           }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -54,7 +54,7 @@ export default function Navbar() {
   }, []);
 
   return (
-    <nav className="bg-green-700 text-white shadow-md">
+    <nav className="bg-green-700 text-white shadow-md relative">
       <div className="container mx-auto px-4 flex items-center justify-between h-20">
         <Link href="/" className="flex items-center hover:opacity-90">
           <Image
@@ -65,18 +65,25 @@ export default function Navbar() {
             height={50}
           />
         </Link>
-        <button
-          className="md:hidden relative w-8 h-8 focus:outline-none"
-          onClick={() => setMenuOpen((o) => !o)}
-          aria-label="Menu"
+        <div
+          className={`absolute right-4 top-1/2 transform -translate-y-1/4 md:hidden ${menuOpen ? "top-1/3" : ""}`}
         >
-          <span
-            className={`absolute top-2 left-1/2 w-6 h-0.5 bg-white transition-transform duration-300 ${menuOpen ? "rotate-45 -translate-x-1/2 translate-y-1" : "-translate-x-1/2"}`}
-          />
-          <span
-            className={`absolute bottom-2 left-1/2 w-6 h-0.5 bg-white transition-transform duration-300 ${menuOpen ? "-rotate-45 -translate-x-1/2 -translate-y-1" : "-translate-x-1/2"}`}
-          />
-        </button>
+          <button
+            onClick={() => setMenuOpen(!menuOpen)}
+            className="flex flex-col justify-center items-center w-8 h-8 focus:outline-none"
+            aria-label="Toggle menu"
+          >
+            <span
+              className={`block h-0.5 w-6 bg-white transition-transform duration-300 ease-in-out ${menuOpen ? "rotate-45 translate-y-1.5" : ""}`}
+            />
+            <span
+              className={`block h-0.5 w-6 bg-white my-1 transition-opacity duration-300 ease-in-out ${menuOpen ? "opacity-0" : "opacity-100"}`}
+            />
+            <span
+              className={`block h-0.5 w-6 bg-white transition-transform duration-300 ease-in-out ${menuOpen ? "-rotate-45 -translate-y-1.5" : ""}`}
+            />
+          </button>
+        </div>
         <div className="hidden md:flex items-center space-x-6">
           <Link
             href="/"
@@ -132,11 +139,11 @@ export default function Navbar() {
         </div>
       </div>
       {menuOpen && (
-        <div className="md:hidden px-4 pb-4 space-y-2 bg-green-700 text-white">
+        <div className="md:hidden bg-green-700 pt-4 pb-6 space-y-4 flex flex-col items-center text-white">
           <Link
             href="/"
             onClick={() => setMenuOpen(false)}
-            className="block py-1"
+            className="w-full text-center py-1"
           >
             Home
           </Link>
@@ -144,7 +151,7 @@ export default function Navbar() {
             <Link
               href={`/profile/${profileUsername}`}
               onClick={() => setMenuOpen(false)}
-              className="block py-1"
+              className="w-full text-center py-1"
             >
               Profile
             </Link>
@@ -153,7 +160,7 @@ export default function Navbar() {
             <Link
               href="/admin"
               onClick={() => setMenuOpen(false)}
-              className="block py-1"
+              className="w-full text-center py-1"
             >
               Admin Panel
             </Link>
@@ -162,7 +169,7 @@ export default function Navbar() {
             <Link
               href="/login"
               onClick={() => setMenuOpen(false)}
-              className="block py-1"
+              className="w-full text-center py-1"
             >
               Log In / Sign Up
             </Link>
@@ -173,7 +180,7 @@ export default function Navbar() {
                 setSession(null);
                 setMenuOpen(false);
               }}
-              className="block py-1 text-left w-full"
+              className="w-full py-1 text-center"
             >
               Sign Out
             </button>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -83,7 +83,7 @@ export default function Navbar() {
           />
         </Link>
         <div
-          className="absolute right-4 top-1/2 -translate-y-1/2 md:hidden"
+          className="absolute right-8 top-1/2 -translate-y-1/2 md:hidden"
         >
           <button
             onClick={() => setMenuOpen(!menuOpen)}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -83,21 +83,20 @@ export default function Navbar() {
           />
         </Link>
         <div
-          className={`absolute right-4 top-1/2 transform -translate-y-1/4 md:hidden ${menuOpen ? "top-1/3" : ""}`}
+          className="absolute right-4 top-1/2 -translate-y-1/2 md:hidden"
         >
           <button
             onClick={() => setMenuOpen(!menuOpen)}
-            className="flex flex-col justify-center items-center w-8 h-8 focus:outline-none"
+            className="relative w-8 h-8 focus:outline-none"
             aria-label="Toggle menu"
           >
             <span
-              className={`block h-0.5 w-6 bg-white transition-transform duration-300 ease-in-out ${menuOpen ? "rotate-45 translate-y-1.5" : ""}`}
+              className={`absolute left-1/2 w-6 h-0.5 bg-white transition-transform duration-300 ease-in-out ${menuOpen ? "rotate-45 top-3.5" : "top-2"}`}
+              style={{ transformOrigin: "center" }}
             />
             <span
-              className={`block h-0.5 w-6 bg-white my-1 transition-opacity duration-300 ease-in-out ${menuOpen ? "opacity-0" : "opacity-100"}`}
-            />
-            <span
-              className={`block h-0.5 w-6 bg-white transition-transform duration-300 ease-in-out ${menuOpen ? "-rotate-45 -translate-y-1.5" : ""}`}
+              className={`absolute left-1/2 w-6 h-0.5 bg-white transition-transform duration-300 ease-in-out ${menuOpen ? "-rotate-45 top-3.5" : "top-5"}`}
+              style={{ transformOrigin: "center" }}
             />
           </button>
         </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -13,6 +13,7 @@ export default function Navbar() {
   const [session, setSession] = useState<Session | null>(null);
   const [profileUsername, setProfileUsername] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
     // fetch initial session
@@ -64,7 +65,19 @@ export default function Navbar() {
             height={50}
           />
         </Link>
-        <div className="flex items-center space-x-6">
+        <button
+          className="md:hidden relative w-8 h-8 focus:outline-none"
+          onClick={() => setMenuOpen((o) => !o)}
+          aria-label="Menu"
+        >
+          <span
+            className={`absolute top-2 left-1/2 w-6 h-0.5 bg-white transition-transform duration-300 ${menuOpen ? "rotate-45 -translate-x-1/2 translate-y-1" : "-translate-x-1/2"}`}
+          />
+          <span
+            className={`absolute bottom-2 left-1/2 w-6 h-0.5 bg-white transition-transform duration-300 ${menuOpen ? "-rotate-45 -translate-x-1/2 -translate-y-1" : "-translate-x-1/2"}`}
+          />
+        </button>
+        <div className="hidden md:flex items-center space-x-6">
           <Link
             href="/"
             className={`${pathname === "/" ? "underline" : "hover:underline"}`}
@@ -118,6 +131,55 @@ export default function Navbar() {
           )}
         </div>
       </div>
+      {menuOpen && (
+        <div className="md:hidden px-4 pb-4 space-y-2 bg-green-700 text-white">
+          <Link
+            href="/"
+            onClick={() => setMenuOpen(false)}
+            className="block py-1"
+          >
+            Home
+          </Link>
+          {profileUsername && (
+            <Link
+              href={`/profile/${profileUsername}`}
+              onClick={() => setMenuOpen(false)}
+              className="block py-1"
+            >
+              Profile
+            </Link>
+          )}
+          {session && isAdmin && (
+            <Link
+              href="/admin"
+              onClick={() => setMenuOpen(false)}
+              className="block py-1"
+            >
+              Admin Panel
+            </Link>
+          )}
+          {!session ? (
+            <Link
+              href="/login"
+              onClick={() => setMenuOpen(false)}
+              className="block py-1"
+            >
+              Log In / Sign Up
+            </Link>
+          ) : (
+            <button
+              onClick={async () => {
+                await supabase.auth.signOut();
+                setSession(null);
+                setMenuOpen(false);
+              }}
+              className="block py-1 text-left w-full"
+            >
+              Sign Out
+            </button>
+          )}
+        </div>
+      )}
     </nav>
   );
 }

--- a/src/components/ProducerCard.tsx
+++ b/src/components/ProducerCard.tsx
@@ -47,6 +47,7 @@ export default function ProducerCard({
           initialAverage={average}
           userRating={userVote}
           readOnly
+          compact
           navigateOnClick
           linkSlug={producer.slug ?? producer.id}
         />

--- a/src/components/ProfileImageUpload.tsx
+++ b/src/components/ProfileImageUpload.tsx
@@ -54,12 +54,12 @@ export default function ProfileImageUpload({
             className="w-24 h-24 rounded-full object-cover"
           />
           <div className="absolute inset-0 rounded-full bg-black/50 opacity-100 sm:opacity-0 sm:hover:opacity-100 flex items-center justify-center transition">
-            <UploadButton onChange={handleChange} className="bg-white text-black" />
+            <UploadButton onChange={handleChange} className="text-black" />
           </div>
           <button
             type="button"
             onClick={remove}
-            className="absolute -top-1 -right-1 bg-white rounded-full text-xs px-1 border"
+            className="absolute -top-1 -right-1 rounded-full text-xs px-1.25 border"
           >
             x
           </button>

--- a/src/components/ProfileImageUpload.tsx
+++ b/src/components/ProfileImageUpload.tsx
@@ -53,7 +53,7 @@ export default function ProfileImageUpload({
             alt="profile"
             className="w-24 h-24 rounded-full object-cover"
           />
-          <div className="absolute inset-0 rounded-full bg-black/50 opacity-0 hover:opacity-100 flex items-center justify-center transition">
+          <div className="absolute inset-0 rounded-full bg-black/50 opacity-100 sm:opacity-0 sm:hover:opacity-100 flex items-center justify-center transition">
             <UploadButton onChange={handleChange} className="bg-white text-black" />
           </div>
           <button

--- a/src/components/UploadButton.tsx
+++ b/src/components/UploadButton.tsx
@@ -6,16 +6,26 @@ export default function UploadButton({
   onChange,
   multiple = false,
   className = "",
+  disabled = false,
+  onClick,
 }: {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   multiple?: boolean;
   className?: string;
+  disabled?: boolean;
+  onClick?: () => void;
 }) {
   const id = useId();
   return (
     <label
       htmlFor={id}
-      className={`inline-flex items-center bg-blue-600 hover:bg-blue-700 text-white p-2 rounded-md cursor-pointer ${className}`}
+      className={`inline-flex items-center ${disabled ? "bg-gray-400 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-700 cursor-pointer"} text-white p-2 rounded-md ${className}`}
+      onClick={(e) => {
+        if (disabled) {
+          e.preventDefault();
+          onClick?.();
+        }
+      }}
     >
       <Upload className="w-4 h-4" />
       <input
@@ -25,6 +35,7 @@ export default function UploadButton({
         multiple={multiple}
         onChange={onChange}
         className="hidden"
+        disabled={disabled}
       />
     </label>
   );

--- a/src/components/UploadButton.tsx
+++ b/src/components/UploadButton.tsx
@@ -19,7 +19,7 @@ export default function UploadButton({
   return (
     <label
       htmlFor={id}
-      className={`inline-flex items-center ${disabled ? "bg-gray-400 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-700 cursor-pointer"} text-white p-2 rounded-md ${className}`}
+      className={`inline-flex items-center ${disabled ? "bg-gray-400 cursor-not-allowed" : "bg-green-600 hover:bg-green-700 cursor-pointer"} text-white p-2 rounded-md ${className}`}
       onClick={(e) => {
         if (disabled) {
           e.preventDefault();

--- a/src/components/VoteButton.tsx
+++ b/src/components/VoteButton.tsx
@@ -14,6 +14,7 @@ export default function VoteButton({
   navigateOnClick = false,
   showNumber = true,
   linkSlug,
+  compact = false,
 }: {
   producerId: string;
   initialAverage: number;
@@ -22,6 +23,7 @@ export default function VoteButton({
   navigateOnClick?: boolean;
   showNumber?: boolean;
   linkSlug?: string;
+  compact?: boolean;
 }) {
   const router = useRouter();
   const [session, setSession] = useState<Session | null>(null);
@@ -61,7 +63,7 @@ export default function VoteButton({
   };
 
   return (
-    <div className="flex items-center space-x-1">
+    <div className={`flex items-center ${compact ? "space-x-0.5" : "space-x-1"}`}>
       {[1, 2, 3, 4, 5].map((n) => {
         const display = readOnly ? initialAverage : rating;
         const fraction = Math.max(0, Math.min(display - (n - 1), 1));
@@ -71,13 +73,13 @@ export default function VoteButton({
             onClick={() => cast(n)}
             className={`p-0.5 ${!readOnly || navigateOnClick ? "cursor-pointer" : ""}`}
           >
-            <div className="relative w-5 h-5">
-              <Star className="absolute w-5 h-5 text-gray-400" />
+            <div className={`relative ${compact ? "w-4 h-4" : "w-5 h-5"}`}>
+              <Star className={`absolute ${compact ? "w-4 h-4" : "w-5 h-5"} text-gray-400`} />
               <div
                 className="absolute overflow-hidden top-0 left-0"
                 style={{ width: `${fraction * 100}%` }}
               >
-                <Star className="w-5 h-5 text-yellow-400 fill-yellow-400" />
+                <Star className={`${compact ? "w-4 h-4" : "w-5 h-5"} text-yellow-400 fill-yellow-400`} />
               </div>
             </div>
           </button>


### PR DESCRIPTION
## Summary
- add collapsible mobile navbar with animated button
- disable comment form actions for guests
- show profile pictures, usernames, and delete option on comments
- refine ingredients modal style and producer page header layout
- allow compact stars and adjust producer card display
- make profile image upload usable on mobile
- support deleting comments via API

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run build` *(fails: Supabase environment variables missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f90dbe8f0832d8408637c38a47c63