### PR TITLE
Add search bar and local storage toggle

### DIFF
--- a/src/components/ProducerList.tsx
+++ b/src/components/ProducerList.tsx
@@ -17,13 +17,17 @@ export type ProducerWithVotes = Producer & {
 interface Props {
   initialData: {
     flower: ProducerWithVotes[];
-    hash:   ProducerWithVotes[];
+    hash: ProducerWithVotes[];
   };
   userVotes?: Record<string, number>; // Added userVotes to Props
   initialView?: "flower" | "hash";
 }
 
-export default function ProducerList({ initialData, userVotes, initialView }: Props) {
+export default function ProducerList({
+  initialData,
+  userVotes,
+  initialView,
+}: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [view, setView] = useState<"flower" | "hash">(initialView ?? "flower");
@@ -63,7 +67,7 @@ export default function ProducerList({ initialData, userVotes, initialView }: Pr
     if (!searchTerm) return true;
     try {
       const escaped = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const regex = new RegExp(`\\b${escaped}`, "i");
+      const regex = new RegExp(`(?<!['’])\\b${escaped}`, "i");
       return regex.test(producer.name);
     } catch {
       return producer.name.toLowerCase().startsWith(searchTerm.toLowerCase());
@@ -82,7 +86,10 @@ export default function ProducerList({ initialData, userVotes, initialView }: Pr
       <div className="grid md:grid-cols-2 gap-4">
         {filteredList.map((producer, i) => {
           const userVoteValue = userVotes?.[producer.id];
-          console.log(`[ProducerList.tsx] Mapping producer ${producer.id}: userVoteValue =`, userVoteValue);
+          console.log(
+            `[ProducerList.tsx] Mapping producer ${producer.id}: userVoteValue =`,
+            userVoteValue
+          );
           return (
             <ProducerCard
               key={producer.id}

--- a/src/components/ProducerList.tsx
+++ b/src/components/ProducerList.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import SearchBar from "./SearchBar";
 import ProducerCard from "./ProducerCard";
 import CategoryToggle from "./CategoryToggle"; // Import CategoryToggle
@@ -23,34 +24,49 @@ interface Props {
 }
 
 export default function ProducerList({ initialData, userVotes, initialView }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [view, setView] = useState<"flower" | "hash">(initialView ?? "flower");
   const [searchTerm, setSearchTerm] = useState<string>("");
 
-  // Initialize view from localStorage if available
+  // Initialize view from url params or localStorage
   useEffect(() => {
+    const param = searchParams.get("view");
+    if (param === "flower" || param === "hash") {
+      setView(param);
+      return;
+    }
     const stored = localStorage.getItem("terptier_view");
     if (stored === "flower" || stored === "hash") {
       setView(stored);
     }
-  }, []);
+  }, [searchParams]);
 
-  // Persist view selection
+  // Persist view selection and update url without full reload
   useEffect(() => {
     localStorage.setItem("terptier_view", view);
-  }, [view]);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("view", view);
+    router.replace(`/?${params.toString()}`, { scroll: false });
+  }, [view, router, searchParams]);
 
   const updateView = (v: "flower" | "hash") => {
     setView(v);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("view", v);
+    router.replace(`/?${params.toString()}`, { scroll: false });
+    localStorage.setItem("terptier_view", v);
   };
   const list = view === "flower" ? initialData.flower : initialData.hash;
 
   const filteredList = list.filter((producer) => {
     if (!searchTerm) return true;
     try {
-      const regex = new RegExp(searchTerm, "i");
+      const escaped = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const regex = new RegExp(`\\b${escaped}`, "i");
       return regex.test(producer.name);
     } catch {
-      return producer.name.toLowerCase().includes(searchTerm.toLowerCase());
+      return producer.name.toLowerCase().startsWith(searchTerm.toLowerCase());
     }
   });
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { useState } from "react";
+
+export default function SearchBar({
+  onSearch,
+  initialQuery = "",
+}: {
+  onSearch: (q: string) => void;
+  initialQuery?: string;
+}) {
+  const [query, setQuery] = useState(initialQuery);
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSearch(query.trim());
+  };
+
+  return (
+    <form onSubmit={submit} className="mb-4 flex justify-center">
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search producers..."
+        className="border rounded-l px-3 py-2 w-2/3 md:w-1/3"
+      />
+      <button
+        type="submit"
+        className="bg-green-600 text-white px-4 py-2 rounded-r"
+      >
+        Search
+      </button>
+    </form>
+  );
+}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export default function SearchBar({
   onSearch,
@@ -10,25 +10,22 @@ export default function SearchBar({
 }) {
   const [query, setQuery] = useState(initialQuery);
 
-  const submit = (e: React.FormEvent) => {
-    e.preventDefault();
-    onSearch(query.trim());
-  };
+  // Trigger search automatically with a short debounce
+  useEffect(() => {
+    const id = setTimeout(() => {
+      onSearch(query.trim());
+    }, 300);
+    return () => clearTimeout(id);
+  }, [query, onSearch]);
 
   return (
-    <form onSubmit={submit} className="mb-4 flex justify-center">
+    <div className="mb-4 flex justify-center">
       <input
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Search producers..."
-        className="border rounded-l px-3 py-2 w-2/3 md:w-1/3"
+        className="border px-3 py-2 rounded w-2/3 md:w-1/3"
       />
-      <button
-        type="submit"
-        className="bg-green-600 text-white px-4 py-2 rounded-r"
-      >
-        Search
-      </button>
-    </form>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow producers list to remember chosen view in localStorage so toggling is faster
- add a `SearchBar` component and use it to filter producers

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_685fad3f5c68832d99de57653649fd7a