### PR TITLE
Update rank card colors

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -106,14 +106,28 @@ export default async function ProfilePage({
         <h2 className="text-xl font-semibold mb-4 border-b pb-2">Rated Producers</h2>
         {likedProducers.length > 0 ? (
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {likedProducers.map((producer, index) => (
-              <ProducerCard
-                key={producer.id}
-                rank={index + 1} // Rank within the liked list
-                producer={producer} // producer is already ProducerWithVotes
-                userVoteValue={producer.userActualVote} // User's actual vote (e.g. 1)
-              />
-            ))}
+            {likedProducers.map((producer, index) => {
+              const rank = index + 1;
+              const j = rank % 10;
+              const k = rank % 100;
+              const suffix = j === 1 && k !== 11 ? "st" : j === 2 && k !== 12 ? "nd" : j === 3 && k !== 13 ? "rd" : "th";
+              let color: "gold" | "silver" | "bronze" | "gray" | "green" = "green";
+              if (rank === 1) color = "gold";
+              else if (rank === 2) color = "silver";
+              else if (rank === 3) color = "bronze";
+              else if (rank > 10) color = "gray";
+
+              return (
+                <ProducerCard
+                  key={producer.id}
+                  rank={rank}
+                  rankSuffix={suffix}
+                  producer={producer}
+                  userVoteValue={producer.userActualVote}
+                  color={color}
+                />
+              );
+            })}
           </div>
         ) : (
           <p className="text-gray-600">No rated producers yet.</p>

--- a/src/components/ProducerCard.tsx
+++ b/src/components/ProducerCard.tsx
@@ -9,19 +9,21 @@ import type { ProducerWithVotes } from "./ProducerList";
 export default function ProducerCard({
   rank,
   producer,
-  userVoteValue, // Added userVoteValue prop
+  userVoteValue,
   isTopTen,
   color = "green",
+  rankSuffix = "",
 }: {
   rank: number;
   producer: ProducerWithVotes;
-  userVoteValue?: number | null; // Added userVoteValue prop type
+  userVoteValue?: number | null;
   isTopTen?: boolean;
   color?: "gold" | "silver" | "bronze" | "gray" | "green";
+  rankSuffix?: string;
 }) {
   const total = producer.votes.reduce((sum, v) => sum + v.value, 0);
   const average = producer.votes.length ? total / producer.votes.length : 0;
-  const userVote = userVoteValue; // Use the passed prop
+  const userVote = userVoteValue;
 
   const colorClasses: Record<string, string> = {
     gold: "bg-gradient-to-br from-yellow-300 to-yellow-600 text-yellow-100",
@@ -40,8 +42,6 @@ export default function ProducerCard({
       ? "glow-bronze"
       : "";
 
-  console.log(`[ProducerCard.tsx] producer ${producer.id}: received userVoteValue =`, userVoteValue, "Passing to VoteButton:", userVote);
-
   const link = `/producer/${producer.slug ?? producer.id}`;
 
   return (
@@ -50,7 +50,10 @@ export default function ProducerCard({
       className={`${isTopTen === false ? "bg-gray-100" : "bg-white"} ${glowClass} p-4 rounded shadow flex items-center space-x-4 hover:bg-gray-50 transition`}
     >
       <div className={`flex items-center justify-center ${colorClasses[color]} rounded-md w-10 h-10 font-bold`}>
-        #{rank}
+        {rank}
+        {rankSuffix && (
+          <sup className="text-[0.6rem] ml-0.5 align-super">{rankSuffix}</sup>
+        )}
       </div>
       {producer.profileImage || producer.logoUrl ? (
         <img

--- a/src/components/ProducerCard.tsx
+++ b/src/components/ProducerCard.tsx
@@ -49,10 +49,10 @@ export default function ProducerCard({
       href={link}
       className={`${isTopTen === false ? "bg-gray-100" : "bg-white"} ${glowClass} p-4 rounded shadow flex items-center space-x-4 hover:bg-gray-50 transition`}
     >
-      <div className={`flex items-center justify-center ${colorClasses[color]} rounded-md w-10 h-10 font-bold`}>
+      <div className={`flex items-center justify-center ${colorClasses[color]} rounded-full w-10 h-10 font-bold`}>
         {rank}
         {rankSuffix && (
-          <sup className="text-[0.6rem] ml-0.5 align-super">{rankSuffix}</sup>
+          <sup className="text-[0.5rem] ml-0.25 align-super">{rankSuffix}</sup>
         )}
       </div>
       {producer.profileImage || producer.logoUrl ? (

--- a/src/components/ProducerCard.tsx
+++ b/src/components/ProducerCard.tsx
@@ -11,15 +11,34 @@ export default function ProducerCard({
   producer,
   userVoteValue, // Added userVoteValue prop
   isTopTen,
+  color = "green",
 }: {
   rank: number;
   producer: ProducerWithVotes;
   userVoteValue?: number | null; // Added userVoteValue prop type
   isTopTen?: boolean;
+  color?: "gold" | "silver" | "bronze" | "gray" | "green";
 }) {
   const total = producer.votes.reduce((sum, v) => sum + v.value, 0);
   const average = producer.votes.length ? total / producer.votes.length : 0;
   const userVote = userVoteValue; // Use the passed prop
+
+  const colorClasses: Record<string, string> = {
+    gold: "bg-gradient-to-br from-yellow-300 to-yellow-600 text-yellow-100",
+    silver: "bg-gradient-to-br from-gray-300 to-gray-500 text-gray-100",
+    bronze: "bg-gradient-to-br from-orange-300 to-orange-700 text-orange-100",
+    gray: "bg-gray-400 text-white",
+    green: "bg-green-600 text-white",
+  };
+
+  const glowClass =
+    color === "gold"
+      ? "glow-gold"
+      : color === "silver"
+      ? "glow-silver"
+      : color === "bronze"
+      ? "glow-bronze"
+      : "";
 
   console.log(`[ProducerCard.tsx] producer ${producer.id}: received userVoteValue =`, userVoteValue, "Passing to VoteButton:", userVote);
 
@@ -28,9 +47,9 @@ export default function ProducerCard({
   return (
     <Link
       href={link}
-      className={`${isTopTen === false ? "bg-gray-100" : "bg-white"} p-4 rounded shadow flex items-center space-x-4 hover:bg-gray-50 transition`}
+      className={`${isTopTen === false ? "bg-gray-100" : "bg-white"} ${glowClass} p-4 rounded shadow flex items-center space-x-4 hover:bg-gray-50 transition`}
     >
-      <div className="flex items-center justify-center bg-green-600 text-white rounded-md w-10 h-10 font-bold">
+      <div className={`flex items-center justify-center ${colorClasses[color]} rounded-md w-10 h-10 font-bold`}>
         #{rank}
       </div>
       {producer.profileImage || producer.logoUrl ? (

--- a/src/components/ProducerList.tsx
+++ b/src/components/ProducerList.tsx
@@ -90,13 +90,21 @@ export default function ProducerList({
             `[ProducerList.tsx] Mapping producer ${producer.id}: userVoteValue =`,
             userVoteValue
           );
+          const rank = i + 1;
+          let color: "gold" | "silver" | "bronze" | "gray" | "green" = "green";
+          if (rank === 1) color = "gold";
+          else if (rank === 2) color = "silver";
+          else if (rank === 3) color = "bronze";
+          else if (rank > 10) color = "gray";
+
           return (
             <ProducerCard
               key={producer.id}
-              rank={i + 1}
+              rank={rank}
               producer={producer}
               userVoteValue={userVoteValue} // Pass down the specific user vote
               isTopTen={i < 10}
+              color={color}
             />
           );
         })}

--- a/src/components/ProducerList.tsx
+++ b/src/components/ProducerList.tsx
@@ -74,7 +74,15 @@ export default function ProducerList({
     }
   });
 
-  console.log("[ProducerList.tsx] userVotes prop:", userVotes);
+  const getSuffix = (n: number) => {
+    const j = n % 10;
+    const k = n % 100;
+    if (j === 1 && k !== 11) return "st";
+    if (j === 2 && k !== 12) return "nd";
+    if (j === 3 && k !== 13) return "rd";
+    return "th";
+  };
+
 
   return (
     <>
@@ -86,23 +94,21 @@ export default function ProducerList({
       <div className="grid md:grid-cols-2 gap-4">
         {filteredList.map((producer, i) => {
           const userVoteValue = userVotes?.[producer.id];
-          console.log(
-            `[ProducerList.tsx] Mapping producer ${producer.id}: userVoteValue =`,
-            userVoteValue
-          );
           const rank = i + 1;
           let color: "gold" | "silver" | "bronze" | "gray" | "green" = "green";
           if (rank === 1) color = "gold";
           else if (rank === 2) color = "silver";
           else if (rank === 3) color = "bronze";
           else if (rank > 10) color = "gray";
+          const suffix = getSuffix(rank);
 
           return (
             <ProducerCard
               key={producer.id}
               rank={rank}
+              rankSuffix={suffix}
               producer={producer}
-              userVoteValue={userVoteValue} // Pass down the specific user vote
+              userVoteValue={userVoteValue}
               isTopTen={i < 10}
               color={color}
             />

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -24,7 +24,7 @@ export default function SearchBar({
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Search producers..."
-        className="border px-3 py-2 rounded w-2/3 md:w-1/3"
+        className="border px-3 py-2 rounded-full w-5/6 md:w-2/3"
       />
     </div>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,1 +1,25 @@
 @import "tailwindcss";
+
+@keyframes glow {
+  0%, 100% {
+    filter: drop-shadow(0 0 5px var(--glow-color));
+  }
+  50% {
+    filter: drop-shadow(0 0 10px var(--glow-color));
+  }
+}
+
+.glow-gold {
+  --glow-color: rgba(255, 215, 0, 0.8);
+  animation: glow 2s infinite;
+}
+
+.glow-silver {
+  --glow-color: rgba(192, 192, 192, 0.8);
+  animation: glow 2s infinite;
+}
+
+.glow-bronze {
+  --glow-color: rgba(205, 127, 50, 0.8);
+  animation: glow 2s infinite;
+}


### PR DESCRIPTION
## Summary
- add color prop to `ProducerCard` and apply metallic gradients
- compute color in `ProducerList`
- create glow animations for top ranks

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build` *(fails: Supabase env vars missing)*

------
https://chatgpt.com/codex/tasks/task_e_68600370cee4832d8c7f38e7993a34ea