### PR TITLE
Handle blob deletion on updates

### DIFF
--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prismadb";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
+import { del } from "@vercel/blob";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -126,6 +127,16 @@ export async function DELETE(request: NextRequest) {
       { success: false, error: "Not authorized" },
       { status: 403 }
     );
+  }
+
+  if (comment.imageUrls?.length) {
+    for (const url of comment.imageUrls) {
+      try {
+        await del(new URL(url).pathname);
+      } catch (err) {
+        console.error("Failed to delete blob", err);
+      }
+    }
   }
 
   await prisma.comment.delete({ where: { id } });

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prismadb";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
+import { del } from "@vercel/blob";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
@@ -60,10 +61,23 @@ export async function PATCH(request: Request) {
 
   const { profilePicUrl } = await request.json();
 
+  const existing = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    select: { profilePicUrl: true },
+  });
+
   await prisma.user.update({
     where: { email: session.user.email },
     data: { profilePicUrl },
   });
+
+  if (existing?.profilePicUrl && existing.profilePicUrl !== profilePicUrl) {
+    try {
+      await del(new URL(existing.profilePicUrl).pathname);
+    } catch (err) {
+      console.error("Failed to delete old profile blob", err);
+    }
+  }
 
   return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
## Summary
- clean up comment image blobs when deleting comments
- remove old profile pictures after users update theirs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68602f7695a4832d9e74b80519d889c3