### PR TITLE
Add option to hide ranking bubble

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -125,6 +125,7 @@ export default async function ProfilePage({
                   producer={producer}
                   userVoteValue={producer.userActualVote}
                   color={color}
+                  showRank={false}
                 />
               );
             })}

--- a/src/components/ProducerCard.tsx
+++ b/src/components/ProducerCard.tsx
@@ -13,6 +13,7 @@ export default function ProducerCard({
   isTopTen,
   color = "green",
   rankSuffix = "",
+  showRank = true,
 }: {
   rank: number;
   producer: ProducerWithVotes;
@@ -20,6 +21,7 @@ export default function ProducerCard({
   isTopTen?: boolean;
   color?: "gold" | "silver" | "bronze" | "gray" | "green";
   rankSuffix?: string;
+  showRank?: boolean;
 }) {
   const total = producer.votes.reduce((sum, v) => sum + v.value, 0);
   const average = producer.votes.length ? total / producer.votes.length : 0;
@@ -49,12 +51,16 @@ export default function ProducerCard({
       href={link}
       className={`${isTopTen === false ? "bg-gray-100" : "bg-white"} ${glowClass} p-4 rounded shadow flex items-center space-x-4 hover:bg-gray-50 transition`}
     >
-      <div className={`flex items-center justify-center ${colorClasses[color]} rounded-full w-10 h-10 font-bold`}>
-        {rank}
-        {rankSuffix && (
-          <sup className="text-[0.5rem] ml-0.25 align-super">{rankSuffix}</sup>
-        )}
-      </div>
+      {showRank && (
+        <div
+          className={`flex items-center justify-center ${colorClasses[color]} rounded-full w-10 h-10 font-bold`}
+        >
+          {rank}
+          {rankSuffix && (
+            <sup className="text-[0.5rem] ml-0.25 align-super">{rankSuffix}</sup>
+          )}
+        </div>
+      )}
       {producer.profileImage || producer.logoUrl ? (
         <img
           src={producer.profileImage || producer.logoUrl!}


### PR DESCRIPTION
## Summary
- allow ProducerCard to optionally hide ranking badge
- turn off ranking numbers for producers on profile page

## Testing
- `npm run lint` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860489e56cc832d9986783fc57acebb