### PR TITLE
Fix comment edit rights on profile page

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -58,6 +58,7 @@ export default async function ProfilePage({
   }
 
   const isOwner = session?.user?.email === user.email;
+  const currentViewerId = session?.user?.id;
 
   // Process votes into liked and disliked producers
   const likedProducers = user.votes
@@ -94,7 +95,7 @@ export default async function ProfilePage({
         {user.comments.length > 0 ? (
           <div>
             {user.comments.map((c) => (
-              <CommentCard key={c.id} comment={c} currentUserId={user.id} showRating={false} />
+              <CommentCard key={c.id} comment={c} currentUserId={currentViewerId} showRating={false} />
             ))}
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- prevent non-owners from seeing edit/delete buttons on profile comments

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68659e7a0c28832db9f40117799b7c47