### PR TITLE
Update producer card coloring

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -112,11 +112,6 @@ export default async function ProfilePage({
               const j = rank % 10;
               const k = rank % 100;
               const suffix = j === 1 && k !== 11 ? "st" : j === 2 && k !== 12 ? "nd" : j === 3 && k !== 13 ? "rd" : "th";
-              let color: "gold" | "silver" | "bronze" | "gray" | "green" = "green";
-              if (rank === 1) color = "gold";
-              else if (rank === 2) color = "silver";
-              else if (rank === 3) color = "bronze";
-              else if (rank > 10) color = "gray";
 
               return (
                 <ProducerCard
@@ -125,7 +120,8 @@ export default async function ProfilePage({
                   rankSuffix={suffix}
                   producer={producer}
                   userVoteValue={producer.userActualVote}
-                  color={color}
+                  color="none"
+                  useColors={false}
                   showRank={false}
                 />
               );

--- a/src/components/ProducerCard.tsx
+++ b/src/components/ProducerCard.tsx
@@ -14,14 +14,16 @@ export default function ProducerCard({
   color = "green",
   rankSuffix = "",
   showRank = true,
+  useColors = true,
 }: {
   rank: number;
   producer: ProducerWithVotes;
   userVoteValue?: number | null;
   isTopTen?: boolean;
-  color?: "gold" | "silver" | "bronze" | "gray" | "green";
+  color?: "gold" | "silver" | "bronze" | "gray" | "green" | "none";
   rankSuffix?: string;
   showRank?: boolean;
+  useColors?: boolean;
 }) {
   const total = producer.votes.reduce((sum, v) => sum + v.value, 0);
   const average = producer.votes.length ? total / producer.votes.length : 0;
@@ -33,18 +35,21 @@ export default function ProducerCard({
     bronze: "bg-gradient-to-br from-orange-300 to-orange-700 text-orange-100",
     gray: "bg-gray-400 text-white",
     green: "bg-green-600 text-white",
+    none: "bg-gray-200 text-gray-700",
   };
 
   const glowClass =
-    color === "gold"
+    useColors && color === "gold"
       ? "glow-gold"
-      : color === "silver"
+      : useColors && color === "silver"
       ? "glow-silver"
-      : color === "bronze"
+      : useColors && color === "bronze"
       ? "glow-bronze"
       : "";
 
   const link = `/producer/${producer.slug ?? producer.id}`;
+
+  const badgeClasses = `flex items-center justify-center ${colorClasses[useColors ? color : "none"]} rounded-full w-10 h-10 font-bold`;
 
   return (
     <Link
@@ -52,9 +57,7 @@ export default function ProducerCard({
       className={`${isTopTen === false ? "bg-gray-100" : "bg-white"} ${glowClass} p-4 rounded shadow flex items-center space-x-4 hover:bg-gray-50 transition`}
     >
       {showRank && (
-        <div
-          className={`flex items-center justify-center ${colorClasses[color]} rounded-full w-10 h-10 font-bold`}
-        >
+        <div className={badgeClasses}>
           {rank}
           {rankSuffix && (
             <sup className="text-[0.5rem] ml-0.25 align-super">{rankSuffix}</sup>

--- a/src/components/ProducerList.tsx
+++ b/src/components/ProducerList.tsx
@@ -21,12 +21,14 @@ interface Props {
   };
   userVotes?: Record<string, number>; // Added userVotes to Props
   initialView?: "flower" | "hash";
+  useColors?: boolean;
 }
 
 export default function ProducerList({
   initialData,
   userVotes,
   initialView,
+  useColors = true,
 }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -102,6 +104,8 @@ export default function ProducerList({
           else if (rank > 10) color = "gray";
           const suffix = getSuffix(rank);
 
+          const finalColor = useColors ? color : ("none" as const);
+
           return (
             <ProducerCard
               key={producer.id}
@@ -110,7 +114,8 @@ export default function ProducerList({
               producer={producer}
               userVoteValue={userVoteValue}
               isTopTen={i < 10}
-              color={color}
+              color={finalColor}
+              useColors={useColors}
             />
           );
         })}


### PR DESCRIPTION
## Summary
- add optional `useColors` prop to `ProducerCard`
- allow disabling colors via `useColors` prop in `ProducerList`
- remove colored styles in profile producer list

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6865c60d99a4832d92255c7564412670