### PR TITLE
Add global 404 and error pages

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function Error({ error, reset }: ErrorProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20">
+      <h2 className="text-2xl font-bold text-red-600">Something went wrong!</h2>
+      <p className="mt-2 text-lg">{error.message}</p>
+      <button
+        onClick={reset}
+        className="mt-4 rounded bg-blue-600 px-4 py-2 text-white"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,11 @@
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20">
+      <h2 className="text-2xl font-bold">404 - Page Not Found</h2>
+      <p className="mt-2 text-lg">Sorry, we couldn\'t find that page.</p>
+      <a href="/" className="mt-4 text-blue-600 underline">
+        Go back home
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- provide a friendly 404 page via `src/app/not-found.tsx`
- handle uncaught server errors via `src/app/error.tsx`

## Testing
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_686ed0107930832d9a2739295ee33a98