### PR TITLE
Add legal and info pages with footer links

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,12 @@
+export default function AboutPage() {
+  return (
+    <div className="prose mx-auto py-10">
+      <h1>About TerpTier</h1>
+      <p>
+        TerpTier is a community driven resource for cannabis enthusiasts in
+        Colorado. Our goal is to highlight the best producers and connect fans
+        of quality flower and concentrates.
+      </p>
+    </div>
+  );
+}

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,0 +1,11 @@
+export default function FAQPage() {
+  return (
+    <div className="prose mx-auto py-10">
+      <h1>Frequently Asked Questions</h1>
+      <h2>How do I vote?</h2>
+      <p>Create an account, verify your age and then visit the rankings page to cast your votes.</p>
+      <h2>Is TerpTier free?</h2>
+      <p>Yes, using the site is completely free.</p>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "../styles/globals.css"; // your tailwind imports
 import Navbar from "@/components/Navbar";
 import MainContainer from "@/components/MainContainer";
+import Footer from "@/components/Footer";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -15,9 +16,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-gray-50">
+      <body className="min-h-screen bg-gray-50 flex flex-col">
         <Navbar />
         <MainContainer>{children}</MainContainer>
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,16 @@
+export default function PrivacyPage() {
+  return (
+    <div className="prose mx-auto py-10">
+      <h1>Privacy Policy</h1>
+      <p>
+        We value your privacy. Information collected on this site is used solely
+        for providing and improving our services. We do not sell your personal
+        information.
+      </p>
+      <p>
+        By using TerpTier you consent to the collection and use of information
+        as described in this policy.
+      </p>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,17 @@
+export default function TermsPage() {
+  return (
+    <div className="prose mx-auto py-10">
+      <h1>Terms of Service</h1>
+      <p>
+        Welcome to TerpTier. By accessing or using our website you agree to the
+        following terms and conditions. Use this site responsibly and in
+        accordance with all applicable laws.
+      </p>
+      <p>
+        All content on this site is provided for informational purposes only and
+        does not constitute legal advice. We reserve the right to modify these
+        terms at any time.
+      </p>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export default function Footer() {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="bg-gray-100 border-t mt-12">
+      <div className="container mx-auto px-4 py-6 text-center text-sm text-gray-600 space-y-2">
+        <div className="flex flex-wrap justify-center gap-4">
+          <Link href="/about" className="hover:underline">
+            About
+          </Link>
+          <Link href="/faq" className="hover:underline">
+            FAQ
+          </Link>
+          <Link href="/terms" className="hover:underline">
+            Terms of Service
+          </Link>
+          <Link href="/privacy" className="hover:underline">
+            Privacy Policy
+          </Link>
+        </div>
+        <p>&copy; {year} TerpTier</p>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- add Terms, Privacy, About and FAQ pages
- create a `Footer` component linking these pages
- include the footer in the site layout

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: Supabase env vars missing)*

------
https://chatgpt.com/codex/tasks/task_e_687407631698832d9cf2aa9326579444