### PR TITLE
Add dynamic sitemap

### DIFF
--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,0 +1,46 @@
+import { prisma } from "@/lib/prismadb";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const baseUrl = new URL(request.url).origin;
+
+  const staticPaths = [
+    "",
+    "/about",
+    "/faq",
+    "/privacy",
+    "/terms",
+    "/login",
+    "/signup",
+    "/rankings",
+  ];
+
+  const producers = await prisma.producer.findMany({
+    select: { slug: true, id: true },
+  });
+  const producerPaths = producers.map((p) => `/producer/${p.slug ?? p.id}`);
+
+  const users = await prisma.user.findMany({
+    select: { username: true, id: true },
+  });
+  const profilePaths = users.map((u) => `/profile/${u.username ?? u.id}`);
+
+  const urls = [...staticPaths, ...producerPaths, ...profilePaths].map((path) => {
+    const loc = `${baseUrl}${path}`;
+    return `<url><loc>${loc}</loc></url>`;
+  });
+
+  const xml =
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` +
+    urls.join("") +
+    `</urlset>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/xml",
+    },
+  });
+}
+


### PR DESCRIPTION
## Summary
- generate sitemap.xml from DB entries

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d8fc67a0832d8e7c0290c9c7c17e