### PR TITLE
Add category-specific attributes and tooltips

### DIFF
--- a/src/app/producer/[slug]/page.tsx
+++ b/src/app/producer/[slug]/page.tsx
@@ -191,11 +191,14 @@ export default async function ProducerProfilePage({
         {producer.attributes && producer.attributes.length > 0 && (
           <div className="flex flex-wrap gap-2 mt-4">
             {producer.attributes.map((a) => {
-              const opt = ATTRIBUTE_OPTIONS.find((o) => o.key === a);
+              const opt = ATTRIBUTE_OPTIONS[producer.category].find(
+                (o) => o.key === a
+              );
               return (
                 <span
                   key={a}
                   className="text-sm bg-gray-200 rounded-full px-3 py-1 flex items-center gap-1"
+                  title={opt?.tooltip}
                 >
                   <span>{opt?.icon}</span>
                   <span>{opt?.label || a}</span>

--- a/src/app/producer/[slug]/page.tsx
+++ b/src/app/producer/[slug]/page.tsx
@@ -10,6 +10,7 @@ import BackButton from "@/components/BackButton";
 import { ExternalLink } from "lucide-react";
 import { createSupabaseServerClient } from "@/lib/supabaseServer";
 import { ATTRIBUTE_OPTIONS } from "@/constants/attributes";
+import Tooltip from "@/components/Tooltip";
 
 // Helper function to capitalize category
 const capitalize = (s: string) =>
@@ -195,14 +196,12 @@ export default async function ProducerProfilePage({
                 (o) => o.key === a
               );
               return (
-                <span
-                  key={a}
-                  className="text-sm bg-gray-200 rounded-full px-3 py-1 flex items-center gap-1"
-                  title={opt?.tooltip}
-                >
-                  <span>{opt?.icon}</span>
-                  <span>{opt?.label || a}</span>
-                </span>
+                <Tooltip key={a} content={opt?.tooltip}>
+                  <span className="text-sm bg-gray-200 rounded-full px-3 py-1 flex items-center gap-1">
+                    <span>{opt?.icon}</span>
+                    <span>{opt?.label || a}</span>
+                  </span>
+                </Tooltip>
               );
             })}
           </div>

--- a/src/components/AddProducerForm.tsx
+++ b/src/components/AddProducerForm.tsx
@@ -87,7 +87,7 @@ export default function AddProducerForm({
         className="border p-2 rounded w-full"
       />
       <div className="flex flex-wrap gap-2">
-        {ATTRIBUTE_OPTIONS.map((attr) => (
+        {ATTRIBUTE_OPTIONS[category].map((attr) => (
           <label key={attr.key} className="flex items-center space-x-1 text-sm">
             <input
               type="checkbox"

--- a/src/components/AttributesFilter.tsx
+++ b/src/components/AttributesFilter.tsx
@@ -4,9 +4,11 @@ import { ATTRIBUTE_OPTIONS } from "@/constants/attributes";
 export default function AttributesFilter({
   selected,
   onChange,
+  category,
 }: {
   selected: string[];
   onChange: (attrs: string[]) => void;
+  category: "FLOWER" | "HASH";
 }) {
   const toggle = (key: string) => {
     const newValues = selected.includes(key)
@@ -17,7 +19,7 @@ export default function AttributesFilter({
 
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-      {ATTRIBUTE_OPTIONS.map((attr) => (
+      {ATTRIBUTE_OPTIONS[category].map((attr) => (
         <label
           key={attr.key}
           className="flex items-center gap-2 bg-gray-100 rounded px-2 py-1 text-sm"

--- a/src/components/ProducerCard.tsx
+++ b/src/components/ProducerCard.tsx
@@ -86,7 +86,9 @@ export default function ProducerCard({
         {producer.attributes && producer.attributes.length > 0 && (
           <div className="flex flex-wrap gap-1 mt-2">
             {producer.attributes.map((a) => {
-              const opt = ATTRIBUTE_OPTIONS.find((o) => o.key === a);
+              const opt = ATTRIBUTE_OPTIONS[producer.category].find(
+                (o) => o.key === a
+              );
               return (
                 <span
                   key={a}

--- a/src/components/ProducerCard.tsx
+++ b/src/components/ProducerCard.tsx
@@ -6,6 +6,7 @@ import VoteButton from "./VoteButton";
 import { MessageCircle } from "lucide-react";
 import type { ProducerWithVotes } from "./ProducerList";
 import { ATTRIBUTE_OPTIONS } from "@/constants/attributes";
+import Tooltip from "./Tooltip";
 
 export default function ProducerCard({
   rank,
@@ -90,12 +91,11 @@ export default function ProducerCard({
                 (o) => o.key === a
               );
               return (
-                <span
-                  key={a}
-                  className="text-xs bg-gray-200 rounded-full px-2 py-0.5 flex items-center"
-                >
-                  <span>{opt?.icon}</span>
-                </span>
+                <Tooltip key={a} content={opt?.tooltip}>
+                  <span className="text-xs bg-gray-200 rounded-full px-2 py-0.5 flex items-center">
+                    <span>{opt?.icon}</span>
+                  </span>
+                </Tooltip>
               );
             })}
           </div>

--- a/src/components/ProducerList.tsx
+++ b/src/components/ProducerList.tsx
@@ -108,6 +108,7 @@ export default function ProducerList({
         onSearch={setSearchTerm}
         selectedAttributes={selectedAttributes}
         onAttributesChange={setSelectedAttributes}
+        category={view === "flower" ? "FLOWER" : "HASH"}
       />
       <div className="grid md:grid-cols-2 gap-4 mx-4 mb-4">
         {filteredList.map((producer, i) => {

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -7,11 +7,13 @@ export default function SearchBar({
   initialQuery = "",
   selectedAttributes = [],
   onAttributesChange,
+  category,
 }: {
   onSearch: (q: string) => void;
   initialQuery?: string;
   selectedAttributes?: string[];
   onAttributesChange: (attrs: string[]) => void;
+  category: "FLOWER" | "HASH";
 }) {
   const [query, setQuery] = useState(initialQuery);
   const [isFocused, setIsFocused] = useState(false);
@@ -134,6 +136,7 @@ export default function SearchBar({
           <AttributesFilter
             selected={selectedAttributes}
             onChange={onAttributesChange}
+            category={category}
           />
         </div>
       )}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { ReactNode, useState, useEffect, useRef } from "react";
+
+interface TooltipProps {
+  content: ReactNode;
+  children: ReactNode;
+}
+
+export default function Tooltip({ content, children }: TooltipProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
+  }, [open]);
+
+  return (
+    <span
+      ref={ref}
+      className="relative inline-block"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onClick={(e) => {
+        e.stopPropagation();
+        setOpen((o) => !o);
+      }}
+    >
+      {children}
+      {open && (
+        <span className="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 whitespace-nowrap bg-gray-800 text-white text-xs rounded px-2 py-1 shadow z-50">
+          {content}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/constants/attributes.ts
+++ b/src/constants/attributes.ts
@@ -2,14 +2,106 @@ export interface AttributeOption {
   key: string;
   label: string;
   icon: string;
+  tooltip: string;
 }
 
-export const ATTRIBUTE_OPTIONS: AttributeOption[] = [
-  { key: 'outdoor', label: 'Outdoor', icon: '☀️' },
-  { key: 'indoor', label: 'Indoor', icon: '🏠' },
-  { key: 'hydroponic', label: 'Hydroponic', icon: '💧' },
-    { key: 'soil-grown', label: 'Soil Grown', icon: '🪴' },
-  { key: 'organic', label: 'Organic', icon: '🌱' },
-    { key: 'salts', label: 'Salts Used', icon: '🧂' },
-  { key: 'living soil', label: 'Living Soil', icon: '🪱' },
+export const FLOWER_ATTRIBUTES: AttributeOption[] = [
+  {
+    key: 'outdoor',
+    label: 'Outdoor',
+    icon: '☀️',
+    tooltip: 'Cultivated outside using natural sunlight',
+  },
+  {
+    key: 'indoor',
+    label: 'Indoor',
+    icon: '🏠',
+    tooltip: 'Cultivated indoors with controlled environment',
+  },
+  {
+    key: 'hydroponic',
+    label: 'Hydroponic',
+    icon: '💧',
+    tooltip: 'Grown using nutrient-rich water instead of soil',
+  },
+  {
+    key: 'soil-grown',
+    label: 'Soil Grown',
+    icon: '🪴',
+    tooltip: 'Grown traditionally in soil',
+  },
+  {
+    key: 'organic',
+    label: 'Organic',
+    icon: '🌱',
+    tooltip: 'Produced without synthetic chemicals',
+  },
+  {
+    key: 'salts',
+    label: 'Salts Used',
+    icon: '🧂',
+    tooltip: 'Uses salt-based nutrients',
+  },
+  {
+    key: 'living soil',
+    label: 'Living Soil',
+    icon: '🪱',
+    tooltip: 'Cultivated in living soil with active microbes',
+  },
 ];
+
+export const HASH_ATTRIBUTES: AttributeOption[] = [
+  {
+    key: 'living soil',
+    label: 'Living Soil',
+    icon: '🪱',
+    tooltip: 'Cultivated in living soil with active microbes',
+  },
+  {
+    key: 'single source',
+    label: 'Single Source',
+    icon: '🎯',
+    tooltip: "Made from the producer's own plants",
+  },
+  {
+    key: 'stainless bags',
+    label: 'Stainless Bags',
+    icon: '🔩',
+    tooltip: 'Uses stainless steel mesh bags for washing',
+  },
+  {
+    key: 'nylon bags',
+    label: 'Nylon Bags',
+    icon: '👜',
+    tooltip: 'Uses nylon mesh bags for washing',
+  },
+  {
+    key: 'cold cure',
+    label: 'Cold Cure',
+    icon: '❄️',
+    tooltip: 'Hash cured at cold temperatures',
+  },
+  {
+    key: 'fresh press',
+    label: 'Fresh Press',
+    icon: '🆕',
+    tooltip: 'Hash jarred immediately after pressing',
+  },
+  {
+    key: '90u',
+    label: '90u',
+    icon: '9️⃣0️⃣',
+    tooltip: 'Filtered through a 90 micron screen',
+  },
+  {
+    key: 'full spec',
+    label: 'Full Spec',
+    icon: '📊',
+    tooltip: 'Contains a full spectrum of resin sizes',
+  },
+];
+
+export const ATTRIBUTE_OPTIONS: Record<'FLOWER' | 'HASH', AttributeOption[]> = {
+  FLOWER: FLOWER_ATTRIBUTES,
+  HASH: HASH_ATTRIBUTES,
+};


### PR DESCRIPTION
## Summary
- support flower/hash specific attribute lists with tooltips
- show appropriate attributes in AddProducerForm, ProducerCard, SearchBar filters and producer pages
- display attribute explanations via native tooltips

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_687d210e742c832d83f692c974596d93