### PR TITLE
Add ProducerRatingSnapshot model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,7 @@ model Producer {
   createdById String?
   votes       Vote[]
   comments    Comment[]
+  ratingSnapshots ProducerRatingSnapshot[]
 
   @@unique([name, category])
 }
@@ -79,4 +80,16 @@ model Comment {
   updatedAt  DateTime @updatedAt
 
   @@unique([userId, producerId])
+}
+
+model ProducerRatingSnapshot {
+  id         String   @id @default(cuid())
+  producer   Producer @relation(fields: [producerId], references: [id], onDelete: Cascade)
+  producerId String
+  average    Float
+  rank       Int
+  voteCount  Int
+  createdAt  DateTime @default(now())
+
+  @@index([producerId, createdAt])
 }


### PR DESCRIPTION
## Summary
- add `ProducerRatingSnapshot` model to Prisma schema
- link rating snapshots back to `Producer`

## Testing
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db DIRECT_URL=postgresql://user:pass@localhost:5432/db npx prisma migrate dev --name add_rating_snapshot --create-only` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_687d46e16898832db2d04588cef14c5b