### PR TITLE
Add ProducerRatingSnapshot model

### DIFF
--- a/prisma/migrations/20250720203100_add_producer_rating_snapshot/migration.sql
+++ b/prisma/migrations/20250720203100_add_producer_rating_snapshot/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "ProducerRatingSnapshot" (
+    "id" TEXT NOT NULL,
+    "producerId" TEXT NOT NULL,
+    "averageRating" DOUBLE PRECISION NOT NULL,
+    "categoryRank" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProducerRatingSnapshot_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ProducerRatingSnapshot_producerId_createdAt_idx" ON "ProducerRatingSnapshot"("producerId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ProducerRatingSnapshot" ADD CONSTRAINT "ProducerRatingSnapshot_producerId_fkey" FOREIGN KEY ("producerId") REFERENCES "Producer"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,8 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
 
@@ -19,37 +19,38 @@ enum Category {
 }
 
 model User {
-  id           String     @id @default(cuid()) // Reverted to CUID
-  name         String?
-  username     String?    @unique
-  birthday     DateTime?
+  id            String     @id @default(cuid()) // Reverted to CUID
+  name          String?
+  username      String?    @unique
+  birthday      DateTime?
   profilePicUrl String?
-  socialLink   String?
-  email        String     @unique
-  passwordHash String? // for credentials
-  role         Role       @default(USER)
-  votes        Vote[]
-  comments     Comment[]
-  createdAt    DateTime   @default(now())
-  updatedAt    DateTime   @updatedAt
-  Producer     Producer[]
+  socialLink    String?
+  email         String     @unique
+  passwordHash  String? // for credentials
+  role          Role       @default(USER)
+  votes         Vote[]
+  comments      Comment[]
+  createdAt     DateTime   @default(now())
+  updatedAt     DateTime   @updatedAt
+  Producer      Producer[]
 }
 
 model Producer {
-  id          String   @id @default(cuid())
-  name        String
-  category    Category
-  logoUrl     String?
-  profileImage String?
-  website     String?
-  ingredients String?
-  attributes  String[] @default([])
-  slug        String?  @unique
-  createdAt   DateTime @default(now())
-  createdBy   User?    @relation(fields: [createdById], references: [id])
-  createdById String?
-  votes       Vote[]
-  comments    Comment[]
+  id                     String                   @id @default(cuid())
+  name                   String
+  category               Category
+  logoUrl                String?
+  profileImage           String?
+  website                String?
+  ingredients            String?
+  attributes             String[]                 @default([])
+  slug                   String?                  @unique
+  createdAt              DateTime                 @default(now())
+  createdBy              User?                    @relation(fields: [createdById], references: [id])
+  createdById            String?
+  votes                  Vote[]
+  comments               Comment[]
+  ProducerRatingSnapshot ProducerRatingSnapshot[]
 
   @@unique([name, category])
 }
@@ -79,4 +80,15 @@ model Comment {
   updatedAt  DateTime @updatedAt
 
   @@unique([userId, producerId])
+}
+
+model ProducerRatingSnapshot {
+  id            String   @id @default(cuid())
+  producer      Producer @relation(fields: [producerId], references: [id], onDelete: Cascade)
+  producerId    String
+  averageRating Float
+  categoryRank  Int
+  createdAt     DateTime @default(now())
+
+  @@index([producerId, createdAt])
 }


### PR DESCRIPTION
## Summary
- expand Prisma schema with `ProducerRatingSnapshot`
- generate SQL migration for the new table

## Testing
- `npm run lint` *(fails: asks how to configure ESLint)*
- `npx prisma migrate dev --name add_producer_rating_snapshot` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_687d5164980c832da9750fb1f6daabf2