### PR TITLE
Add ranking snapshot cron

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "next start",
     "lint": "next lint",
     "db:seed": "prisma db seed",
-    "migrate:reset": "prisma migrate reset --force"
+    "migrate:reset": "prisma migrate reset --force",
+    "record:snapshot": "ts-node scripts/recordDailyRanking.ts"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/scripts/recordDailyRanking.ts
+++ b/scripts/recordDailyRanking.ts
@@ -1,0 +1,39 @@
+import { prisma } from "@/lib/prismadb";
+import { Category } from "@prisma/client";
+
+export async function recordDailyRanking() {
+  for (const category of [Category.FLOWER, Category.HASH]) {
+    const producers = await prisma.producer.findMany({
+      where: { category },
+      include: { votes: true },
+    });
+
+    const ranked = producers
+      .map((p) => ({
+        id: p.id,
+        avg: p.votes.length
+          ? p.votes.reduce((s, v) => s + v.value, 0) / p.votes.length
+          : 0,
+      }))
+      .sort((a, b) => b.avg - a.avg);
+
+    for (const [index, p] of ranked.entries()) {
+      await prisma.producerRatingSnapshot.create({
+        data: {
+          producerId: p.id,
+          averageRating: p.avg,
+          categoryRank: index + 1,
+        },
+      });
+    }
+  }
+}
+
+if (require.main === module) {
+  recordDailyRanking()
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/src/app/api/cron/record-daily-ranking/route.ts
+++ b/src/app/api/cron/record-daily-ranking/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { recordDailyRanking } from "../../../../../scripts/recordDailyRanking";
+
+export async function GET() {
+  try {
+    await recordDailyRanking();
+    return NextResponse.json({ success: true });
+  } catch (err: any) {
+    console.error("[/api/cron/record-daily-ranking] error:", err);
+    return NextResponse.json(
+      { success: false, error: err.message || "Unknown" },
+      { status: 500 }
+    );
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "crons": [
+    { "path": "/api/cron/record-daily-ranking", "schedule": "0 0 * * *" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a script that records daily producer rankings
- schedule the script via vercel cron
- expose an API route that runs the snapshot job
- wire up npm script `record:snapshot`

## Testing
- `npm run record:snapshot --silent` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_687d5380fff0832da90a8f483af41aac