### PR TITLE
Add producer history API route

### DIFF
--- a/src/app/api/producers/[id]/history/route.ts
+++ b/src/app/api/producers/[id]/history/route.ts
@@ -3,12 +3,13 @@ import { prisma } from "@/lib/prismadb";
 
 export async function GET(
   _req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { id } = await params;
     const snapshots = await prisma.producerRatingSnapshot.findMany({
-      where: { producerId: params.id },
-      orderBy: { createdAt: "asc" }
+      where: { producerId: id },
+      orderBy: { createdAt: "asc" },
     });
     return NextResponse.json({ success: true, snapshots });
   } catch (err: any) {

--- a/src/app/api/producers/[id]/history/route.ts
+++ b/src/app/api/producers/[id]/history/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prismadb";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const snapshots = await prisma.producerRatingSnapshot.findMany({
+      where: { producerId: params.id },
+      orderBy: { createdAt: "asc" }
+    });
+    return NextResponse.json({ success: true, snapshots });
+  } catch (err: any) {
+    console.error("[GET /api/producers/[id]/history]", err);
+    return NextResponse.json(
+      { success: false, error: err.message || "Internal error" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add history route to fetch producer rating snapshots

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_687d56b03ee0832dbf62e531c38202ed