### PR TITLE
Migrate login/logout to server routes

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
+export async function POST(request: Request) {
+  const { email, password } = await request.json();
+  const cookieStore = await cookies();
+  const supabase = createServerActionClient({ cookies: () => cookieStore } as any, {
+    supabaseUrl,
+    supabaseKey,
+  });
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error || !data.user) {
+    return NextResponse.json({ success: false, error: error?.message }, { status: 400 });
+  }
+  return NextResponse.json({ success: true, data });
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
+export async function POST() {
+  const cookieStore = await cookies();
+  const supabase = createServerActionClient({ cookies: () => cookieStore } as any, {
+    supabaseUrl,
+    supabaseKey,
+  });
+  const { error } = await supabase.auth.signOut();
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 400 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -50,15 +50,21 @@ function LoginForm() {
   const handleSignIn = async () => {
     setLoading(true);
     setError(null);
-    const { error: signInError } = await supabase.auth.signInWithPassword({
-      email,
-      password,
+    const res = await fetch("/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
     });
+    const result = await res.json();
 
-    if (signInError) {
-      setError(signInError.message);
+    if (!res.ok || !result.success) {
+      setError(result.error || "Login failed");
       setLoading(false);
       return;
+    }
+
+    if (result.data?.session) {
+      await supabase.auth.setSession(result.data.session);
     }
 
     await finalizeAuth();

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -151,6 +151,7 @@ export default function Navbar() {
             <button
               type="button"
               onClick={async () => {
+                await fetch("/api/auth/logout", { method: "POST" });
                 await supabase.auth.signOut();
                 setCurrentUser(null);
                 location.reload();
@@ -203,6 +204,7 @@ export default function Navbar() {
             <button
               type="button"
               onClick={async () => {
+                await fetch("/api/auth/logout", { method: "POST" });
                 await supabase.auth.signOut();
                 setCurrentUser(null);
                 setMenuOpen(false);


### PR DESCRIPTION
## Summary
- add Supabase SSR login and logout API routes
- update client login to post to `/api/auth/login`
- clear server and client state on logout via `/api/auth/logout`

## Testing
- `npm run lint` *(fails: interactive configuration prompt)*
- `npm run build` *(fails: Supabase environment variables are missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f99a60ccc832d90e3f9e12e9fd968