### PR TITLE
Add username validation

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -6,7 +6,7 @@ import { Role } from "@prisma/client";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const email = searchParams.get("email");
-  const username = searchParams.get("username");
+  const username = searchParams.get("username")?.toLowerCase();
   const getEmail = searchParams.get("getEmail");
 
   if (email) {
@@ -26,10 +26,19 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
-  const { id, email, name, username, birthday, profilePicUrl, socialLink } =
-    await request.json();
+  const {
+    id,
+    email,
+    name,
+    username: rawUsername,
+    birthday,
+    profilePicUrl,
+    socialLink,
+  } = await request.json();
 
-  if (username && !/^[a-zA-Z0-9]+$/.test(username)) {
+  const username = rawUsername?.toLowerCase();
+
+  if (username && !/^[a-z0-9]+$/.test(username)) {
     return NextResponse.json(
       { ok: false, error: "Invalid username" },
       { status: 400 },

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -29,6 +29,13 @@ export async function POST(request: Request) {
   const { id, email, name, username, birthday, profilePicUrl, socialLink } =
     await request.json();
 
+  if (username && !/^[a-zA-Z0-9]+$/.test(username)) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid username" },
+      { status: 400 },
+    );
+  }
+
   const role = email === process.env.ADMIN_EMAIL ? Role.ADMIN : Role.USER;
 
   try {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -96,13 +96,18 @@ export default function SignUpPage() {
     return /^[a-zA-Z0-9]+$/.test(name);
   };
 
+  const normalizeUsername = (name: string): string => name.toLowerCase();
+
   const checkUsername = async (name: string) => {
     if (!name) return;
-    if (!isValidUsername(name)) {
+    const normalized = normalizeUsername(name);
+    if (!isValidUsername(normalized)) {
       setUsernameTaken(false);
       return;
     }
-    const res = await fetch(`/api/users?username=${encodeURIComponent(name)}`);
+    const res = await fetch(
+      `/api/users?username=${encodeURIComponent(normalized)}`,
+    );
     const data = await res.json();
     setUsernameTaken(data.exists);
   };
@@ -146,6 +151,7 @@ export default function SignUpPage() {
     profileUrl: string | null,
     id: string,
     userEmail: string,
+    slugUsername: string,
   ) => {
     const res = await fetch("/api/users", {
       method: "POST",
@@ -154,7 +160,7 @@ export default function SignUpPage() {
         id,
         email: userEmail,
         name: username,
-        username,
+        username: slugUsername,
         birthday,
         profilePicUrl: profileUrl,
         socialLink,
@@ -173,7 +179,9 @@ export default function SignUpPage() {
       return;
     }
 
-    if (!isValidUsername(username)) {
+    const normalized = normalizeUsername(username);
+
+    if (!isValidUsername(normalized)) {
       setError("Username can only contain letters and numbers");
       return;
     }
@@ -197,7 +205,7 @@ export default function SignUpPage() {
 
     // ensure the username is available before creating the Supabase user
     const usernameRes = await fetch(
-      `/api/users?username=${encodeURIComponent(username)}`,
+      `/api/users?username=${encodeURIComponent(normalized)}`,
     );
     const usernameData = await usernameRes.json();
     if (usernameData.exists) {
@@ -228,6 +236,7 @@ export default function SignUpPage() {
         profileUrl ?? null,
         data.user.id,
         data.user.email ?? email,
+        normalized,
       );
       router.push(
         `/login?email=${encodeURIComponent(email)}&message=${encodeURIComponent(

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -92,8 +92,16 @@ export default function SignUpPage() {
     }
   };
 
+  const isValidUsername = (name: string): boolean => {
+    return /^[a-zA-Z0-9]+$/.test(name);
+  };
+
   const checkUsername = async (name: string) => {
     if (!name) return;
+    if (!isValidUsername(name)) {
+      setUsernameTaken(false);
+      return;
+    }
     const res = await fetch(`/api/users?username=${encodeURIComponent(name)}`);
     const data = await res.json();
     setUsernameTaken(data.exists);
@@ -162,6 +170,11 @@ export default function SignUpPage() {
     // Validate email again before submission
     if (!isValidEmail(email)) {
       setError("Please enter a valid email address");
+      return;
+    }
+
+    if (!isValidUsername(username)) {
+      setError("Username can only contain letters and numbers");
       return;
     }
 
@@ -306,6 +319,7 @@ export default function SignUpPage() {
                 name="username"
                 autoComplete="username"
                 required
+                pattern="[A-Za-z0-9]+"
                 placeholder="Username"
                 value={username}
                 onChange={(e) => {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -20,6 +20,9 @@ export default function SignUpPage() {
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [usernameTaken, setUsernameTaken] = useState(false);
+  const [invalidUsernameChars, setInvalidUsernameChars] = useState<string | null>(
+    null,
+  );
   const [loading, setLoading] = useState(false);
   // Email validation function
   const validateEmail = (email: string): boolean => {
@@ -320,7 +323,7 @@ export default function SignUpPage() {
               />
             </label>
           </div>
-          <div>
+          <div className="relative group">
             <label className="block">
               Username <span className="text-red-500">*</span>
               <input
@@ -328,18 +331,37 @@ export default function SignUpPage() {
                 name="username"
                 autoComplete="username"
                 required
-                pattern="[A-Za-z0-9]+"
+                pattern="[a-z0-9]+"
                 placeholder="Username"
                 value={username}
                 onChange={(e) => {
-                  setUsername(e.target.value);
+                  const value = e.target.value;
+                  setUsername(value);
                   setUsernameTaken(false);
+                  const invalid = value.match(/[^a-z0-9]/gi);
+                  if (invalid) {
+                    const unique = Array.from(new Set(invalid)).join(" ");
+                    setInvalidUsernameChars(unique);
+                  } else {
+                    setInvalidUsernameChars(null);
+                  }
                 }}
                 onBlur={(e) => checkUsername(e.target.value)}
-                title={usernameTaken ? "Username already taken" : ""}
+                title={
+                  usernameTaken
+                    ? "Username already taken"
+                    : invalidUsernameChars
+                    ? `Invalid characters: ${invalidUsernameChars}`
+                    : ""
+                }
                 className="w-full mt-1 p-2.5 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
               />
             </label>
+            {invalidUsernameChars && (
+              <div className="absolute right-0 top-full mt-1 bg-white border text-xs p-2 rounded shadow group-focus-within:block group-hover:block">
+                Invalid characters: {invalidUsernameChars}. Usernames can only contain lowercase letters and numbers.
+              </div>
+            )}
             {usernameTaken && (
               <p className="text-red-500 text-sm">Username already taken</p>
             )}


### PR DESCRIPTION
## Summary
- check usernames on the signup page so only letters and numbers are allowed
- enforce the same rule in the users API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887b1a465d0832d91e146b428fb397a