### PR TITLE
Add new Prisma models

### DIFF
--- a/prisma/migrations/20250730160000_add_notifications_and_strain/migration.sql
+++ b/prisma/migrations/20250730160000_add_notifications_and_strain/migration.sql
@@ -1,0 +1,67 @@
+-- AlterEnum
+ALTER TYPE "Role" ADD VALUE 'PRODUCER_ADMIN';
+
+-- CreateTable
+CREATE TABLE "ProducerAdmin" (
+    "userId" TEXT NOT NULL,
+    "producerId" TEXT NOT NULL,
+
+    CONSTRAINT "ProducerAdmin_pkey" PRIMARY KEY ("userId", "producerId")
+);
+
+-- CreateTable
+CREATE TABLE "Strain" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "imageUrl" TEXT,
+    "producerId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Strain_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "readAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "NotificationJob" (
+    "id" TEXT NOT NULL,
+    "notificationId" TEXT NOT NULL,
+    "scheduledAt" TIMESTAMP(3) NOT NULL,
+    "sentAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "NotificationJob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "NotificationPreference" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "email" BOOLEAN NOT NULL DEFAULT true,
+    "sms" BOOLEAN NOT NULL DEFAULT false,
+    "push" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "NotificationPreference_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Strain_producerId_name_key" ON "Strain"("producerId", "name");
+
+-- AddForeignKey
+ALTER TABLE "ProducerAdmin" ADD CONSTRAINT "ProducerAdmin_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ProducerAdmin" ADD CONSTRAINT "ProducerAdmin_producerId_fkey" FOREIGN KEY ("producerId") REFERENCES "Producer"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Strain" ADD CONSTRAINT "Strain_producerId_fkey" FOREIGN KEY ("producerId") REFERENCES "Producer"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "NotificationJob" ADD CONSTRAINT "NotificationJob_notificationId_fkey" FOREIGN KEY ("notificationId") REFERENCES "Notification"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "NotificationPreference" ADD CONSTRAINT "NotificationPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,7 @@ datasource db {
 enum Role {
   USER
   ADMIN
+  PRODUCER_ADMIN
 }
 
 enum Category {
@@ -19,20 +20,23 @@ enum Category {
 }
 
 model User {
-  id            String     @id @default(cuid()) // Reverted to CUID
-  name          String?
-  username      String?    @unique
-  birthday      DateTime?
-  profilePicUrl String?
-  socialLink    String?
-  email         String     @unique
-  passwordHash  String? // for credentials
-  role          Role       @default(USER)
-  votes         Vote[]
-  comments      Comment[]
-  createdAt     DateTime   @default(now())
-  updatedAt     DateTime   @updatedAt
-  Producer      Producer[]
+  id                      String                   @id @default(cuid()) // Reverted to CUID
+  name                    String?
+  username                String?                  @unique
+  birthday                DateTime?
+  profilePicUrl           String?
+  socialLink              String?
+  email                   String                   @unique
+  passwordHash            String? // for credentials
+  role                    Role                     @default(USER)
+  votes                   Vote[]
+  comments                Comment[]
+  producerAdmins          ProducerAdmin[]
+  notifications           Notification[]
+  notificationPreferences NotificationPreference[]
+  createdAt               DateTime                 @default(now())
+  updatedAt               DateTime                 @updatedAt
+  Producer                Producer[]
 }
 
 model Producer {
@@ -51,6 +55,8 @@ model Producer {
   votes                  Vote[]
   comments               Comment[]
   ProducerRatingSnapshot ProducerRatingSnapshot[]
+  admins                 ProducerAdmin[]
+  strains                Strain[]
 
   @@unique([name, category])
 }
@@ -91,4 +97,54 @@ model ProducerRatingSnapshot {
   createdAt     DateTime @default(now())
 
   @@index([producerId, createdAt])
+}
+
+model ProducerAdmin {
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId     String
+  producer   Producer @relation(fields: [producerId], references: [id], onDelete: Cascade)
+  producerId String
+
+  @@id([userId, producerId])
+}
+
+model Strain {
+  id          String   @id @default(cuid())
+  name        String
+  description String?
+  imageUrl    String?
+  producer    Producer @relation(fields: [producerId], references: [id], onDelete: Cascade)
+  producerId  String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([producerId, name])
+}
+
+model Notification {
+  id        String            @id @default(cuid())
+  user      User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  message   String
+  readAt    DateTime?
+  createdAt DateTime          @default(now())
+  jobs      NotificationJob[]
+}
+
+model NotificationJob {
+  id             String       @id @default(cuid())
+  notification   Notification @relation(fields: [notificationId], references: [id], onDelete: Cascade)
+  notificationId String
+  scheduledAt    DateTime
+  sentAt         DateTime?
+  createdAt      DateTime     @default(now())
+}
+
+model NotificationPreference {
+  id     String  @id @default(cuid())
+  user   User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
+  email  Boolean @default(true)
+  sms    Boolean @default(false)
+  push   Boolean @default(false)
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -67,6 +67,29 @@ async function main() {
       create: { name, category: Category.HASH },
     });
   }
+
+  // 4) Seed a producer admin user and link to a couple producers
+  const producerAdminPass = process.env.PRODUCER_ADMIN_PASS || "changeme";
+  const adminHash = await bcrypt.hash(producerAdminPass, 10);
+  const producerAdmin = await prisma.user.upsert({
+    where: { email: "producer_admin@example.com" },
+    update: {},
+    create: {
+      email: "producer_admin@example.com",
+      name: "Producer Admin",
+      passwordHash: adminHash,
+      role: Role.PRODUCER_ADMIN,
+    },
+  });
+
+  const someProducers = await prisma.producer.findMany({ take: 2 });
+  for (const producer of someProducers) {
+    await prisma.producerAdmin.upsert({
+      where: { userId_producerId: { userId: producerAdmin.id, producerId: producer.id } },
+      update: {},
+      create: { userId: producerAdmin.id, producerId: producer.id },
+    });
+  }
 }
 
 main()


### PR DESCRIPTION
## Summary
- add `PRODUCER_ADMIN` to `Role`
- support multiple admins with `ProducerAdmin`
- add notifications & strains models
- seed sample producer admin
- create migration script

## Testing
- `npx prisma generate`
- `npx tsc -p tsconfig.json --noEmit`
- `npx prisma migrate dev --name add_notifications_and_strain --create-only` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_688a4bd42444832dad45765f4b358221