### PR TITLE
Add RLS policies for new tables

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,31 @@
+# Supabase Policies
+
+This folder contains SQL snippets for row level security (RLS) configuration.
+
+Run these statements in your Supabase project to apply the policies.
+
+## Policies
+
+The `policies.sql` file contains statements to enable RLS and define rules for the new tables added in this release:
+
+- `ProducerAdmin`
+- `Strain`
+- `Notification`
+- `NotificationJob`
+- `NotificationPreference`
+
+### Strain
+- Producer admins can insert, update and delete strains that belong to their producer via the `ProducerAdmin` join table.
+- Support or admin roles can read all strains.
+
+### Notifications
+- Support or admin roles can read all `Notification` and `NotificationJob` rows.
+
+### NotificationPreference
+- Users may update only their own notification preference row.
+
+Execute the SQL file after deploying migrations:
+
+```bash
+psql $SUPABASE_DB < supabase/policies.sql
+```

--- a/supabase/policies.sql
+++ b/supabase/policies.sql
@@ -1,0 +1,40 @@
+-- Enable RLS on new tables
+alter table "public"."ProducerAdmin" enable row level security;
+alter table "public"."Strain" enable row level security;
+alter table "public"."Notification" enable row level security;
+alter table "public"."NotificationJob" enable row level security;
+alter table "public"."NotificationPreference" enable row level security;
+
+-- Strain policies
+create policy "producer-admin-manage-strains" on "public"."Strain"
+  for all
+  using (
+    exists (
+      select 1 from "public"."ProducerAdmin" pa
+      where pa.userId = auth.uid()
+        and pa.producerId = "Strain".producerId
+    )
+  )
+  with check (
+    exists (
+      select 1 from "public"."ProducerAdmin" pa
+      where pa.userId = auth.uid()
+        and pa.producerId = "Strain".producerId
+    )
+  );
+
+create policy "support-admin-read-strains" on "public"."Strain"
+  for select using (auth.role() in ('ADMIN','SUPPORT'));
+
+-- Notification policies
+create policy "support-admin-read-notifications" on "public"."Notification"
+  for select using (auth.role() in ('ADMIN','SUPPORT'));
+
+create policy "support-admin-read-notification-jobs" on "public"."NotificationJob"
+  for select using (auth.role() in ('ADMIN','SUPPORT'));
+
+-- NotificationPreference policies
+create policy "user-update-own-preference" on "public"."NotificationPreference"
+  for update
+  using (auth.uid() = "NotificationPreference".userId)
+  with check (auth.uid() = "NotificationPreference".userId);

--- a/supabase/policies.sql
+++ b/supabase/policies.sql
@@ -11,15 +11,15 @@ create policy "producer-admin-manage-strains" on "public"."Strain"
   using (
     exists (
       select 1 from "public"."ProducerAdmin" pa
-      where pa.userId = auth.uid()
-        and pa.producerId = "Strain".producerId
+      where pa."userId"::uuid = (select auth.uid())
+        and pa."producerId" = "Strain"."producerId"
     )
   )
   with check (
     exists (
       select 1 from "public"."ProducerAdmin" pa
-      where pa.userId = auth.uid()
-        and pa.producerId = "Strain".producerId
+      where pa."userId"::uuid = (select auth.uid())
+        and pa."producerId" = "Strain"."producerId"
     )
   );
 
@@ -36,5 +36,5 @@ create policy "support-admin-read-notification-jobs" on "public"."NotificationJo
 -- NotificationPreference policies
 create policy "user-update-own-preference" on "public"."NotificationPreference"
   for update
-  using (auth.uid() = "NotificationPreference".userId)
-  with check (auth.uid() = "NotificationPreference".userId);
+  using ((select auth.uid()) = "NotificationPreference"."userId"::uuid)
+  with check ((select auth.uid()) = "NotificationPreference"."userId"::uuid);


### PR DESCRIPTION
## Summary
- add SQL for enabling RLS and policies
- document policies in `supabase/README.md`

## Testing
- `npm run lint` *(fails: asks interactive questions)*

------
https://chatgpt.com/codex/tasks/task_e_688a51f94f30832d849fdbd98b1f405d