### PR TITLE
Add producer strain admin page

### DIFF
--- a/prisma/migrations/20250805120000_add_release_date_to_strain/migration.sql
+++ b/prisma/migrations/20250805120000_add_release_date_to_strain/migration.sql
@@ -1,0 +1,2 @@
+-- Add releaseDate column to Strain
+ALTER TABLE "Strain" ADD COLUMN "releaseDate" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -112,6 +112,7 @@ model Strain {
   id          String   @id @default(cuid())
   name        String
   description String?
+  releaseDate DateTime?
   imageUrl    String?
   producer    Producer @relation(fields: [producerId], references: [id], onDelete: Cascade)
   producerId  String

--- a/src/app/admin/[slug]/page.tsx
+++ b/src/app/admin/[slug]/page.tsx
@@ -1,0 +1,52 @@
+import { prisma } from "@/lib/prismadb";
+import { createSupabaseServerClient } from "@/lib/supabaseServer";
+import { notFound, redirect } from "next/navigation";
+import StrainManager from "@/components/StrainManager";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProducerAdminPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.user?.email) {
+    redirect("/login?reason=producer_admin");
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    include: { producerAdmins: true },
+  });
+  if (!user) redirect("/login");
+
+  const producer = await prisma.producer.findFirst({
+    where: { OR: [{ slug }, { id: slug }] },
+    include: { strains: true },
+  });
+  if (!producer) return notFound();
+
+  const isAdmin =
+    user.role === "ADMIN" ||
+    user.producerAdmins.some((pa) => pa.producerId === producer.id);
+  if (!isAdmin) redirect("/");
+
+  return (
+    <div className="container mx-auto p-4 md:p-6 lg:p-8">
+      <h1 className="text-3xl font-bold mb-6 text-gray-800">
+        Manage Strains - {producer.name}
+      </h1>
+      <StrainManager
+        producerId={producer.id}
+        initialStrains={producer.strains}
+      />
+    </div>
+  );
+}

--- a/src/app/api/delete/route.ts
+++ b/src/app/api/delete/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: false, error: 'Missing url' }, { status: 400 });
   }
   try {
-    await del(url);
+    await del(url, { token: process.env.BLOB_READ_WRITE_TOKEN });
     return NextResponse.json({ success: true });
   } catch (err) {
     console.error('Failed to delete blob', err);

--- a/src/app/api/strains/[id]/route.ts
+++ b/src/app/api/strains/[id]/route.ts
@@ -7,6 +7,7 @@ interface UpdateStrainBody {
   name?: string;
   description?: string | null;
   imageUrl?: string | null;
+  releaseDate?: string | null;
 }
 
 async function canManageProducer(
@@ -81,7 +82,12 @@ export async function PUT(
   try {
     const strain = await prisma.strain.update({
       where: { id },
-      data: body,
+      data: {
+        name: body.name,
+        description: body.description,
+        imageUrl: body.imageUrl,
+        releaseDate: body.releaseDate ? new Date(body.releaseDate) : body.releaseDate,
+      },
     });
     return NextResponse.json({ success: true, strain });
   } catch (err: any) {

--- a/src/app/api/strains/route.ts
+++ b/src/app/api/strains/route.ts
@@ -8,6 +8,7 @@ interface CreateStrainBody {
   name: string;
   description?: string;
   imageUrl?: string;
+  releaseDate?: string | null;
 }
 
 async function canManageProducer(
@@ -82,6 +83,7 @@ export async function POST(request: NextRequest) {
         name: body.name,
         description: body.description,
         imageUrl: body.imageUrl,
+        releaseDate: body.releaseDate ? new Date(body.releaseDate) : undefined,
       },
     });
     return NextResponse.json({ success: true, strain });

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -43,6 +43,9 @@ export async function POST(request: NextRequest) {
   }
 
   const filename = `${uuid()}-${file.name}`;
-  const blob = await put(filename, buffer, { access: "public" });
+  const blob = await put(filename, buffer, {
+    access: "public",
+    token: process.env.BLOB_READ_WRITE_TOKEN,
+  });
   return NextResponse.json({ success: true, url: blob.url });
 }

--- a/src/components/AddStrainForm.tsx
+++ b/src/components/AddStrainForm.tsx
@@ -15,6 +15,9 @@ export default function AddStrainForm({
   const [name, setName] = useState(strain?.name ?? "");
   const [description, setDescription] = useState(strain?.description ?? "");
   const [imageUrl, setImageUrl] = useState<string | null>(strain?.imageUrl ?? null);
+  const [releaseDate, setReleaseDate] = useState(
+    strain?.releaseDate ? strain.releaseDate.toISOString().slice(0, 10) : "",
+  );
 
   const save = async () => {
     const body = {
@@ -22,6 +25,7 @@ export default function AddStrainForm({
       name,
       description,
       imageUrl,
+      releaseDate: releaseDate ? new Date(releaseDate).toISOString() : null,
     };
     if (strain) {
       await fetch(`/api/strains/${strain.id}`, {
@@ -57,6 +61,13 @@ export default function AddStrainForm({
         placeholder="Description"
         value={description}
         onChange={(e) => setDescription(e.target.value)}
+        className="border p-2 rounded w-full"
+      />
+      <input
+        type="date"
+        placeholder="Release date"
+        value={releaseDate}
+        onChange={(e) => setReleaseDate(e.target.value)}
         className="border p-2 rounded w-full"
       />
       <button

--- a/src/components/AddStrainForm.tsx
+++ b/src/components/AddStrainForm.tsx
@@ -1,0 +1,68 @@
+"use client";
+import { useState } from "react";
+import ImageUpload from "./ImageUpload";
+import type { Strain } from "@prisma/client";
+
+export default function AddStrainForm({
+  producerId,
+  strain,
+  onSaved,
+}: {
+  producerId: string;
+  strain?: Strain;
+  onSaved?: () => void;
+}) {
+  const [name, setName] = useState(strain?.name ?? "");
+  const [description, setDescription] = useState(strain?.description ?? "");
+  const [imageUrl, setImageUrl] = useState<string | null>(strain?.imageUrl ?? null);
+
+  const save = async () => {
+    const body = {
+      producerId,
+      name,
+      description,
+      imageUrl,
+    };
+    if (strain) {
+      await fetch(`/api/strains/${strain.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    } else {
+      await fetch("/api/strains", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    }
+    setName("");
+    setDescription("");
+    setImageUrl(null);
+    onSaved ? onSaved() : window.location.reload();
+  };
+
+  return (
+    <div className="mb-6 space-y-2">
+      <ImageUpload value={imageUrl} onChange={setImageUrl} />
+      <input
+        placeholder="Strain name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="border p-2 rounded w-full"
+      />
+      <textarea
+        placeholder="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        className="border p-2 rounded w-full"
+      />
+      <button
+        onClick={save}
+        className="bg-green-600 text-white px-4 py-2 rounded cursor-pointer"
+      >
+        {strain ? "Save" : "Add"}
+      </button>
+    </div>
+  );
+}

--- a/src/components/AddStrainForm.tsx
+++ b/src/components/AddStrainForm.tsx
@@ -15,8 +15,14 @@ export default function AddStrainForm({
   const [name, setName] = useState(strain?.name ?? "");
   const [description, setDescription] = useState(strain?.description ?? "");
   const [imageUrl, setImageUrl] = useState<string | null>(strain?.imageUrl ?? null);
+  function formatInputDate(date?: string | Date | null) {
+    if (!date) return "";
+    const d = typeof date === "string" ? new Date(date) : date;
+    return d.toISOString().slice(0, 10);
+  }
+
   const [releaseDate, setReleaseDate] = useState(
-    strain?.releaseDate ? strain.releaseDate.toISOString().slice(0, 10) : "",
+    formatInputDate(strain?.releaseDate ?? null),
   );
 
   const save = async () => {
@@ -25,7 +31,7 @@ export default function AddStrainForm({
       name,
       description,
       imageUrl,
-      releaseDate: releaseDate ? new Date(releaseDate).toISOString() : null,
+      releaseDate: releaseDate || null,
     };
     if (strain) {
       await fetch(`/api/strains/${strain.id}`, {

--- a/src/components/AddStrainForm.tsx
+++ b/src/components/AddStrainForm.tsx
@@ -28,12 +28,14 @@ export default function AddStrainForm({
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
+        credentials: "include",
       });
     } else {
       await fetch("/api/strains", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
+        credentials: "include",
       });
     }
     setName("");

--- a/src/components/StrainManager.tsx
+++ b/src/components/StrainManager.tsx
@@ -45,6 +45,9 @@ export default function StrainManager({
                   Name
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Release
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Actions
                 </th>
               </tr>
@@ -54,6 +57,9 @@ export default function StrainManager({
                 <tr key={s.id}>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="text-sm font-medium text-gray-900">{s.name}</div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    {s.releaseDate ? new Date(s.releaseDate).toLocaleDateString() : "-"}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
                     <button

--- a/src/components/StrainManager.tsx
+++ b/src/components/StrainManager.tsx
@@ -16,13 +16,15 @@ export default function StrainManager({
   const [editing, setEditing] = useState<Strain | null>(null);
 
   const refresh = async () => {
-    const res = await fetch(`/api/strains?producerId=${producerId}`);
+    const res = await fetch(`/api/strains?producerId=${producerId}`, {
+      credentials: "include",
+    });
     const data = await res.json();
     if (data.success) setStrains(data.strains);
   };
 
   const deleteStrain = async (id: string) => {
-    await fetch(`/api/strains/${id}`, { method: "DELETE" });
+    await fetch(`/api/strains/${id}`, { method: "DELETE", credentials: "include" });
     setStrains(strains.filter((s) => s.id !== id));
   };
 

--- a/src/components/StrainManager.tsx
+++ b/src/components/StrainManager.tsx
@@ -59,7 +59,9 @@ export default function StrainManager({
                     <div className="text-sm font-medium text-gray-900">{s.name}</div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    {s.releaseDate ? new Date(s.releaseDate).toLocaleDateString() : "-"}
+                    {s.releaseDate
+                      ? new Date(s.releaseDate).toISOString().slice(0, 10)
+                      : "-"}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
                     <button

--- a/src/components/StrainManager.tsx
+++ b/src/components/StrainManager.tsx
@@ -1,0 +1,92 @@
+"use client";
+import { useState } from "react";
+import type { Strain } from "@prisma/client";
+import Modal from "./Modal";
+import AddStrainForm from "./AddStrainForm";
+import { XCircle, FilePenLine } from "lucide-react";
+
+export default function StrainManager({
+  producerId,
+  initialStrains,
+}: {
+  producerId: string;
+  initialStrains: Strain[];
+}) {
+  const [strains, setStrains] = useState<Strain[]>(initialStrains);
+  const [editing, setEditing] = useState<Strain | null>(null);
+
+  const refresh = async () => {
+    const res = await fetch(`/api/strains?producerId=${producerId}`);
+    const data = await res.json();
+    if (data.success) setStrains(data.strains);
+  };
+
+  const deleteStrain = async (id: string) => {
+    await fetch(`/api/strains/${id}`, { method: "DELETE" });
+    setStrains(strains.filter((s) => s.id !== id));
+  };
+
+  return (
+    <div>
+      <div className="mb-8 p-6 bg-white shadow rounded-lg">
+        <h2 className="text-xl font-semibold mb-4">Add Strain</h2>
+        <AddStrainForm producerId={producerId} onSaved={refresh} />
+      </div>
+      <div className="bg-white shadow rounded-lg overflow-x-auto">
+        {strains.length === 0 ? (
+          <p className="p-6 text-center text-gray-500">No strains found.</p>
+        ) : (
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Name
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {strains.map((s) => (
+                <tr key={s.id}>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <div className="text-sm font-medium text-gray-900">{s.name}</div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                    <button
+                      onClick={() => setEditing(s)}
+                      className="text-blue-600 hover:text-blue-800"
+                      aria-label={`Edit ${s.name}`}
+                    >
+                      <FilePenLine size={20} />
+                    </button>
+                    <button
+                      onClick={() => deleteStrain(s.id)}
+                      className="text-red-600 hover:text-red-800"
+                      aria-label={`Delete ${s.name}`}
+                    >
+                      <XCircle size={20} />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+      {editing && (
+        <Modal isOpen={true} onClose={() => setEditing(null)}>
+          <AddStrainForm
+            producerId={producerId}
+            strain={editing}
+            onSaved={() => {
+              setEditing(null);
+              refresh();
+            }}
+          />
+        </Modal>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement dynamic admin route for managing strains
- provide AddStrainForm and StrainManager components
- protect route by verifying session and admin rights

## Testing
- `npx next lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688a868a39d4832db4886b53153cf0dd