### PR TITLE
Add notification settings page

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -6,7 +6,8 @@ import BackButton from "@/components/BackButton";
 import { prisma } from "@/lib/prismadb";
 import { cookies } from "next/headers";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import { Instagram, ExternalLink, Link } from "lucide-react";
+import { Instagram, ExternalLink, Link as LinkIcon, Bell } from "lucide-react";
+import Link from "next/link";
 
 export const dynamic = "force-dynamic";
 
@@ -87,8 +88,17 @@ export default async function ProfilePage({
 
   return (
     <div className="container mx-auto p-4">
-      <div className="mb-4">
+      <div className="mb-4 flex items-center justify-between">
         <BackButton />
+        {isOwner && (
+          <Link
+            href="/profile/notifications"
+            aria-label="Notification settings"
+            className="text-green-600 hover:text-green-800"
+          >
+            <Bell className="w-5 h-5" />
+          </Link>
+        )}
       </div>
       
       {/* Profile Header Card */}
@@ -154,7 +164,7 @@ export default async function ProfilePage({
                           </svg>
                         </div>
                       ) : (
-                        <Link className="w-6 h-6" />
+                        <LinkIcon className="w-6 h-6" />
                       )}
                     </a>
                   );

--- a/src/app/profile/notifications/page.tsx
+++ b/src/app/profile/notifications/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import BackButton from "@/components/BackButton";
+
+interface Pref {
+  email: boolean;
+}
+
+export default function NotificationSettingsPage() {
+  const [pref, setPref] = useState<Pref | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch("/api/notification-preferences");
+        if (!res.ok) throw new Error("failed");
+        const data = await res.json();
+        setPref(data.preference || { email: true });
+      } catch {
+        setError("Failed to load preferences");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const toggleEmail = async () => {
+    if (!pref) return;
+    setSaving(true);
+    try {
+      const res = await fetch("/api/notification-preferences", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: !pref.email }),
+      });
+      if (!res.ok) throw new Error("failed");
+      const data = await res.json();
+      setPref(data.preference);
+    } catch {
+      setError("Failed to update preference");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <div className="mb-4">
+        <BackButton />
+      </div>
+      <h1 className="text-2xl font-bold mb-4">Notification Settings</h1>
+      {error && <p className="text-red-500 mb-2">{error}</p>}
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={pref?.email ?? false}
+            onChange={toggleEmail}
+            disabled={saving}
+          />
+          <span>Receive weekly drop emails</span>
+        </label>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a notification settings page under profile
- link notification settings from your own profile with a bell button

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688aae709098832db114b547aa2ece11