### PR TITLE
feat: add upcoming drops pages

### DIFF
--- a/src/app/drops/[producerSlug]/page.tsx
+++ b/src/app/drops/[producerSlug]/page.tsx
@@ -1,0 +1,53 @@
+// src/app/drops/[producerSlug]/page.tsx
+import Link from "next/link";
+import { prisma } from "@/lib/prismadb";
+import UpcomingStrainList from "@/components/UpcomingStrainList";
+
+interface DropsByProducerPageProps {
+  params: Promise<{ producerSlug: string }>;
+}
+
+export default async function DropsByProducerPage({ params }: DropsByProducerPageProps) {
+  const { producerSlug } = await params;
+
+  const now = new Date();
+  const sevenDays = new Date();
+  sevenDays.setDate(now.getDate() + 7);
+
+  const producer = await prisma.producer.findFirst({
+    where: { OR: [{ slug: producerSlug }, { id: producerSlug }] },
+    include: {
+      strains: {
+        where: { releaseDate: { gte: now, lte: sevenDays } },
+        orderBy: { releaseDate: "asc" },
+      },
+    },
+  });
+
+  if (!producer) {
+    return (
+      <div className="container mx-auto p-4">
+        <p className="text-red-500">Producer not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-6">{producer.name}</h1>
+      {producer.strains.length === 0 ? (
+        <p>No upcoming strains.</p>
+      ) : (
+        <UpcomingStrainList strains={producer.strains} />
+      )}
+      <div className="mt-4">
+        <Link
+          href={`/producer/${producer.slug ?? producer.id}`}
+          className="text-green-700 hover:underline"
+        >
+          View profile
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/drops/page.tsx
+++ b/src/app/drops/page.tsx
@@ -1,0 +1,57 @@
+// src/app/drops/page.tsx
+import Link from "next/link";
+import { prisma } from "@/lib/prismadb";
+import UpcomingStrainList from "@/components/UpcomingStrainList";
+
+export default async function DropsPage() {
+  const now = new Date();
+  const sevenDays = new Date();
+  sevenDays.setDate(now.getDate() + 7);
+
+  const strains = await prisma.strain.findMany({
+    where: { releaseDate: { gte: now, lte: sevenDays } },
+    include: { producer: true },
+    orderBy: { releaseDate: "asc" },
+  });
+
+  const grouped = strains.reduce<Record<string, { producer: typeof strains[number]["producer"]; strains: typeof strains }>>(
+    (acc, strain) => {
+      const producerId = strain.producer.id;
+      if (!acc[producerId]) {
+        acc[producerId] = { producer: strain.producer, strains: [] };
+      }
+      acc[producerId].strains.push(strain);
+      return acc;
+    },
+    {}
+  );
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-6">Upcoming Drops</h1>
+      {Object.values(grouped).length === 0 ? (
+        <p>No upcoming strains this week.</p>
+      ) : (
+        Object.values(grouped).map(({ producer, strains }) => (
+          <div key={producer.id} className="mb-8">
+            <h2 className="text-2xl font-semibold mb-2">
+              <Link
+                href={`/drops/${producer.slug ?? producer.id}`}
+                className="text-green-700 hover:underline"
+              >
+                {producer.name}
+              </Link>
+              <Link
+                href={`/producer/${producer.slug ?? producer.id}`}
+                className="ml-2 text-sm text-gray-500 hover:underline"
+              >
+                Profile
+              </Link>
+            </h2>
+            <UpcomingStrainList strains={strains} />
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -130,6 +130,14 @@ export default function Navbar() {
         <div className="absolute right-8 top-1/2 -translate-y-1/2 md:hidden"></div>
         <div className="hidden md:flex items-center space-x-6">
           <Link
+            href="/drops"
+            className={`${
+              pathname === "/drops" ? "underline" : "hover:underline"
+            }`}
+          >
+            Drops
+          </Link>
+          <Link
             href="/rankings"
             className={`${
               pathname === "/rankings" ? "underline" : "hover:underline"
@@ -188,6 +196,13 @@ export default function Navbar() {
       </div>
       {menuOpen && (
         <div className="md:hidden bg-green-800 border-t border-b border-green-900 pt-4 pb-6 space-y-4 flex flex-col items-center text-white">
+          <Link
+            href="/drops"
+            onClick={() => setMenuOpen(false)}
+            className="w-full text-center py-1"
+          >
+            Drops
+          </Link>
           <Link
             href="/rankings"
             onClick={() => setMenuOpen(false)}

--- a/src/components/UpcomingStrainList.tsx
+++ b/src/components/UpcomingStrainList.tsx
@@ -1,0 +1,27 @@
+// src/components/UpcomingStrainList.tsx
+import type { Strain } from "@prisma/client";
+
+interface UpcomingStrainListProps {
+  strains: Strain[];
+}
+
+export default function UpcomingStrainList({ strains }: UpcomingStrainListProps) {
+  if (strains.length === 0) {
+    return <p className="text-gray-500">No upcoming strains.</p>;
+  }
+
+  return (
+    <ul className="space-y-4">
+      {strains.map((strain) => (
+        <li key={strain.id} className="bg-white shadow rounded p-4">
+          <h3 className="text-lg font-semibold">{strain.name}</h3>
+          {strain.releaseDate && (
+            <p className="text-sm text-gray-500">
+              Releases on {new Date(strain.releaseDate).toLocaleDateString()}
+            </p>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- list upcoming strains grouped by producer
- allow viewing upcoming drops per producer
- add reusable component and navigation link

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: missing ESLint config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68ab53e93710832d8968458087980ed9