### PR TITLE
Show strains on producer page

### DIFF
--- a/src/app/producer/[slug]/page.tsx
+++ b/src/app/producer/[slug]/page.tsx
@@ -8,6 +8,7 @@ import VoteButton from "@/components/VoteButton";
 import IngredientsButton from "@/components/IngredientsButton";
 import BackButton from "@/components/BackButton";
 import ChartToggleWrapper from "@/components/ChartToggleWrapper";
+import UpcomingStrainList from "@/components/UpcomingStrainList";
 import { ExternalLink } from "lucide-react";
 import { createSupabaseServerClient } from "@/lib/supabaseServer";
 import { ATTRIBUTE_OPTIONS } from "@/constants/attributes";
@@ -47,6 +48,7 @@ export default async function ProducerProfilePage({
       votes: true, // To calculate total score
       comments: false,
       _count: { select: { comments: true } },
+      strains: true,
     },
   });
 
@@ -213,9 +215,9 @@ export default async function ProducerProfilePage({
               showNumber={true}
             />
           </div>
-        </div>
+          </div>
 
-        {/* Placeholder for description or other details */}
+          {/* Placeholder for description or other details */}
         {/* Example:
         {producer.description && (
           <div className="mt-6">
@@ -223,12 +225,17 @@ export default async function ProducerProfilePage({
             <p className="text-gray-700 leading-relaxed">{producer.description}</p>
           </div>
         )}
-        */}
+          */}
 
-        {/* Chart Toggle Wrapper - replaces the direct RatingHistoryChart */}
-        <ChartToggleWrapper
-          producerId={producer.id}
-          voteCount={producer.votes.length}
+          <div className="mt-8">
+            <h3 className="text-xl font-semibold mb-4">Strains</h3>
+            <UpcomingStrainList strains={producer.strains} />
+          </div>
+
+          {/* Chart Toggle Wrapper - replaces the direct RatingHistoryChart */}
+          <ChartToggleWrapper
+            producerId={producer.id}
+            voteCount={producer.votes.length}
         />
 
         <div className="mt-8">

--- a/src/components/UpcomingStrainList.tsx
+++ b/src/components/UpcomingStrainList.tsx
@@ -1,5 +1,6 @@
 // src/components/UpcomingStrainList.tsx
 import type { Strain } from "@prisma/client";
+import Image from "next/image";
 
 interface UpcomingStrainListProps {
   strains: Strain[];
@@ -13,13 +14,28 @@ export default function UpcomingStrainList({ strains }: UpcomingStrainListProps)
   return (
     <ul className="space-y-4">
       {strains.map((strain) => (
-        <li key={strain.id} className="bg-white shadow rounded p-4">
-          <h3 className="text-lg font-semibold">{strain.name}</h3>
-          {strain.releaseDate && (
-            <p className="text-sm text-gray-500">
-              Releases on {new Date(strain.releaseDate).toLocaleDateString()}
-            </p>
+        <li
+          key={strain.id}
+          className="bg-white shadow rounded p-4 flex items-center space-x-4"
+        >
+          {strain.imageUrl && (
+            <div className="relative w-16 h-16 flex-shrink-0">
+              <Image
+                src={strain.imageUrl}
+                alt={strain.name}
+                fill
+                className="object-cover rounded"
+              />
+            </div>
           )}
+          <div>
+            <h3 className="text-lg font-semibold">{strain.name}</h3>
+            {strain.releaseDate && (
+              <p className="text-sm text-gray-500">
+                Releases on {new Date(strain.releaseDate).toLocaleDateString()}
+              </p>
+            )}
+          </div>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- fetch strains with each producer query
- list producer strains on profile page using shared UpcomingStrainList
- enhance UpcomingStrainList to show strain images

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68ab57bf3098832daca41c4079929870