### PR TITLE
Add notification opt-in and use placehold.co

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,7 @@ const nextConfig = {
   images: {
     remotePatterns: [
       new URL('https://elnwy0xndspvgnal.public.blob.vercel-storage.com/**'),
-      new URL('https://via.placeholder.com/**'),
+      new URL('https://placehold.co/**'),
     ],
   },
 };

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -34,6 +34,7 @@ export async function POST(request: Request) {
     birthday,
     profilePicUrl,
     socialLink,
+    notificationOptIn,
   } = await request.json();
 
   const username = rawUsername?.toLowerCase();
@@ -58,6 +59,7 @@ export async function POST(request: Request) {
         birthday: birthday ? new Date(birthday) : undefined,
         profilePicUrl,
         socialLink,
+        notificationOptIn,
         role,
       },
       create: {
@@ -68,6 +70,7 @@ export async function POST(request: Request) {
         birthday: birthday ? new Date(birthday) : undefined,
         profilePicUrl,
         socialLink,
+        notificationOptIn,
         role,
       },
     });

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -13,6 +13,7 @@ export default function SignUpPage() {
   const [username, setUsername] = useState("");
   const [birthday, setBirthday] = useState("");
   const [socialLink, setSocialLink] = useState("");
+  const [notificationOptIn, setNotificationOptIn] = useState(false);
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
   const [file, setFile] = useState<File | null>(null);
@@ -167,6 +168,7 @@ export default function SignUpPage() {
         birthday,
         profilePicUrl: profileUrl,
         socialLink,
+        notificationOptIn,
       }),
     });
     const data = await res.json();
@@ -389,6 +391,15 @@ export default function SignUpPage() {
               className="w-full mt-1 p-2.5 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              checked={notificationOptIn}
+              onChange={(e) => setNotificationOptIn(e.target.checked)}
+              className="mr-2"
+            />
+            Receive weekly drop emails
+          </label>
           <div>
             <label className="block">Profile Picture</label>
             <UploadButton onChange={handleFileChange} className="mt-1" />

--- a/src/components/UpcomingStrainList.tsx
+++ b/src/components/UpcomingStrainList.tsx
@@ -26,7 +26,7 @@ export default function UpcomingStrainList({ strains }: UpcomingStrainListProps)
           >
             <div className="relative w-16 h-16 flex-shrink-0">
               <Image
-                src={strain.imageUrl || "https://via.placeholder.com/64"}
+                src={strain.imageUrl || "https://placehold.co/64"}
                 alt={strain.name}
                 fill
                 className="object-cover rounded"


### PR DESCRIPTION
## Summary
- add weekly drop email opt-in on signup and include value in user creation
- persist `notificationOptIn` in user API
- use placehold.co for placeholder strain images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5f6635cc832db9fab152810705fc