### PR TITLE
Add drop opt-in modal and extend user API

### DIFF
--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -39,7 +39,7 @@ export async function GET() {
     role: user.role,
     username: user.username,
     profilePicUrl: user.profilePicUrl,
-    notificationOptIn: (user as any).notificationOptIn,
+    notificationOptIn: user.notificationOptIn,
   });
 }
 
@@ -61,9 +61,13 @@ export async function PATCH(request: Request) {
 
   const { profilePicUrl, notificationOptIn } = await request.json();
 
+  const data: { profilePicUrl?: string; notificationOptIn?: boolean } = {};
+  if (profilePicUrl !== undefined) data.profilePicUrl = profilePicUrl;
+  if (notificationOptIn !== undefined) data.notificationOptIn = notificationOptIn;
+
   await prisma.user.update({
     where: { email: session.user.email },
-    data: { profilePicUrl, notificationOptIn } as any,
+    data,
   });
 
   return NextResponse.json({ success: true });

--- a/src/components/DropOptInModal.tsx
+++ b/src/components/DropOptInModal.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+import Modal from './Modal';
+
+interface Props {
+  onClose: () => void;
+  onOptIn?: () => void;
+}
+
+export default function DropOptInModal({ onClose, onOptIn }: Props) {
+  const [open, setOpen] = useState(true);
+
+  const setCookie = (name: string, value: string, days: number) => {
+    const date = new Date();
+    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+    document.cookie = `${name}=${value}; expires=${date.toUTCString()}; path=/; SameSite=Lax`;
+  };
+
+  const handleClose = () => {
+    setCookie('dropOptInPrompt', 'done', 365);
+    setOpen(false);
+    onClose();
+  };
+
+  const handleYes = async () => {
+    try {
+      await fetch('/api/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notificationOptIn: true }),
+      });
+      onOptIn?.();
+    } catch (err) {
+      console.error('Failed to update notification setting', err);
+    } finally {
+      handleClose();
+    }
+  };
+
+  return (
+    <Modal isOpen={open} onClose={handleClose}>
+      <h2 className="text-xl font-semibold mb-4 text-center">
+        Get notified about new drops?
+      </h2>
+      <div className="flex justify-center space-x-4">
+        <button
+          onClick={handleClose}
+          className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300"
+        >
+          No
+        </button>
+        <button
+          onClick={handleYes}
+          className="px-4 py-2 rounded bg-green-600 text-white hover:bg-green-700"
+        >
+          Yes
+        </button>
+      </div>
+    </Modal>
+  );
+}
+

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,6 +9,7 @@ import { supabase } from "@/lib/supabaseClient";
 import Image from "next/image";
 import { LogIn, LogOut } from "lucide-react";
 import type { Session } from "@supabase/supabase-js";
+import DropOptInModal from "./DropOptInModal";
 
 export default function Navbar() {
   const pathname = usePathname();
@@ -17,6 +18,8 @@ export default function Navbar() {
   const [isAdmin, setIsAdmin] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [showBar, setShowBar] = useState(true);
+  const [notificationOptIn, setNotificationOptIn] = useState(true);
+  const [showDropModal, setShowDropModal] = useState(false);
   const lastScrollY = useRef(0);
 
   useEffect(() => {
@@ -33,6 +36,10 @@ export default function Navbar() {
             if (data.success) {
               setProfileUsername(data.username || data.id);
               setIsAdmin(data.role === "ADMIN");
+              setNotificationOptIn(data.notificationOptIn);
+              if (!data.notificationOptIn && !document.cookie.includes('dropOptInPrompt=')) {
+                setShowDropModal(true);
+              }
             }
           }
         } catch (err) {
@@ -52,22 +59,36 @@ export default function Navbar() {
               if (data.success) {
                 setProfileUsername(data.username || data.id);
                 setIsAdmin(data.role === "ADMIN");
+                setNotificationOptIn(data.notificationOptIn);
+                if (!data.notificationOptIn && !document.cookie.includes('dropOptInPrompt=')) {
+                  setShowDropModal(true);
+                } else {
+                  setShowDropModal(false);
+                }
               } else {
                 setProfileUsername(null);
                 setIsAdmin(false);
+                setNotificationOptIn(true);
+                setShowDropModal(false);
               }
             } else {
               setProfileUsername(null);
               setIsAdmin(false);
+              setNotificationOptIn(true);
+              setShowDropModal(false);
             }
           } catch (err) {
             console.error("Failed to fetch user", err);
             setProfileUsername(null);
             setIsAdmin(false);
+            setNotificationOptIn(true);
+            setShowDropModal(false);
           }
         } else {
           setProfileUsername(null);
           setIsAdmin(false);
+          setNotificationOptIn(true);
+          setShowDropModal(false);
         }
       }
     );
@@ -91,6 +112,7 @@ export default function Navbar() {
   }, []);
 
   return (
+    <>
     <motion.nav
       initial={{ y: 0 }}
       animate={{ y: showBar ? 0 : -80 }}
@@ -255,5 +277,12 @@ export default function Navbar() {
         </div>
       )}
     </motion.nav>
+    {showDropModal && (
+      <DropOptInModal
+        onOptIn={() => setNotificationOptIn(true)}
+        onClose={() => setShowDropModal(false)}
+      />
+    )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add DropOptInModal component prompting users to receive drop emails and sets a cookie
- extend `/api/users/me` to expose and update `notificationOptIn`
- show opt-in modal from Navbar when user is logged in, not opted in, and no cookie set

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ab68c85cb4832daf7a0337e6a46c09