### PR TITLE
Add strainSlug to strains and expose via API

### DIFF
--- a/prisma/migrations/20250826120000_add_strain_slug/migration.sql
+++ b/prisma/migrations/20250826120000_add_strain_slug/migration.sql
@@ -1,0 +1,3 @@
+-- Add strainSlug column to Strain
+ALTER TABLE "Strain" ADD COLUMN "strainSlug" SERIAL;
+CREATE UNIQUE INDEX "Strain_strainSlug_key" ON "Strain"("strainSlug");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -109,6 +109,7 @@ model ProducerAdmin {
 
 model Strain {
   id          String   @id @default(cuid())
+  strainSlug  Int      @default(autoincrement()) @unique
   name        String
   description String?
   releaseDate DateTime?

--- a/src/app/admin/[slug]/page.tsx
+++ b/src/app/admin/[slug]/page.tsx
@@ -29,7 +29,18 @@ export default async function ProducerAdminPage({
 
   const producer = await prisma.producer.findFirst({
     where: { OR: [{ slug }, { id: slug }] },
-    include: { strains: true },
+    include: {
+      strains: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          imageUrl: true,
+          releaseDate: true,
+          strainSlug: true,
+        },
+      },
+    },
   });
   if (!producer) return notFound();
 

--- a/src/app/api/strains/[id]/route.ts
+++ b/src/app/api/strains/[id]/route.ts
@@ -40,7 +40,20 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const strain = await prisma.strain.findUnique({ where: { id } });
+    const strain = await prisma.strain.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        strainSlug: true,
+        name: true,
+        description: true,
+        imageUrl: true,
+        releaseDate: true,
+        producerId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
     if (!strain) {
       return NextResponse.json({ success: false, error: "Not found" }, { status: 404 });
     }
@@ -87,6 +100,17 @@ export async function PUT(
         description: body.description,
         imageUrl: body.imageUrl,
         releaseDate: body.releaseDate ? new Date(body.releaseDate) : body.releaseDate,
+      },
+      select: {
+        id: true,
+        strainSlug: true,
+        name: true,
+        description: true,
+        imageUrl: true,
+        releaseDate: true,
+        producerId: true,
+        createdAt: true,
+        updatedAt: true,
       },
     });
     return NextResponse.json({ success: true, strain });

--- a/src/app/api/strains/route.ts
+++ b/src/app/api/strains/route.ts
@@ -51,7 +51,20 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const strains = await prisma.strain.findMany({ where: { producerId } });
+    const strains = await prisma.strain.findMany({
+      where: { producerId },
+      select: {
+        id: true,
+        strainSlug: true,
+        name: true,
+        description: true,
+        imageUrl: true,
+        releaseDate: true,
+        producerId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
     return NextResponse.json({ success: true, strains });
   } catch (err: any) {
     console.error("[GET /api/strains]", err);
@@ -84,6 +97,17 @@ export async function POST(request: NextRequest) {
         description: body.description,
         imageUrl: body.imageUrl,
         releaseDate: body.releaseDate ? new Date(body.releaseDate) : undefined,
+      },
+      select: {
+        id: true,
+        strainSlug: true,
+        name: true,
+        description: true,
+        imageUrl: true,
+        releaseDate: true,
+        producerId: true,
+        createdAt: true,
+        updatedAt: true,
       },
     });
     return NextResponse.json({ success: true, strain });

--- a/src/app/drops/[producerSlug]/page.tsx
+++ b/src/app/drops/[producerSlug]/page.tsx
@@ -37,6 +37,14 @@ export default async function DropsByProducerPage({
           },
         },
         orderBy: { releaseDate: "asc" },
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          imageUrl: true,
+          releaseDate: true,
+          strainSlug: true,
+        },
       },
     },
   });

--- a/src/app/drops/page.tsx
+++ b/src/app/drops/page.tsx
@@ -12,8 +12,22 @@ export default async function DropsPage() {
 
   const strains = await prisma.strain.findMany({
     where: { releaseDate: { gte: now, lte: sevenDays } },
-    include: { 
-      producer: true
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      imageUrl: true,
+      releaseDate: true,
+      strainSlug: true,
+      producer: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          category: true,
+          profileImage: true,
+        },
+      },
     },
     orderBy: { releaseDate: "asc" },
   });

--- a/src/app/producer/[slug]/page.tsx
+++ b/src/app/producer/[slug]/page.tsx
@@ -49,7 +49,16 @@ export default async function ProducerProfilePage({
       votes: true, // To calculate total score
       comments: false,
       _count: { select: { comments: true } },
-      strains: true,
+      strains: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          imageUrl: true,
+          releaseDate: true,
+          strainSlug: true,
+        },
+      },
     },
   });
 

--- a/src/components/AddStrainForm.tsx
+++ b/src/components/AddStrainForm.tsx
@@ -3,13 +3,18 @@ import { useState } from "react";
 import ImageUpload from "./ImageUpload";
 import type { Strain } from "@prisma/client";
 
+type StrainWithSlug = Pick<
+  Strain,
+  "id" | "name" | "description" | "imageUrl" | "releaseDate" | "strainSlug"
+>;
+
 export default function AddStrainForm({
   producerId,
   strain,
   onSaved,
 }: {
   producerId: string;
-  strain?: Strain;
+  strain?: StrainWithSlug;
   onSaved?: () => void;
 }) {
   const [name, setName] = useState(strain?.name ?? "");

--- a/src/components/StrainManager.tsx
+++ b/src/components/StrainManager.tsx
@@ -5,15 +5,20 @@ import Modal from "./Modal";
 import AddStrainForm from "./AddStrainForm";
 import { XCircle, FilePenLine } from "lucide-react";
 
+type StrainWithSlug = Pick<
+  Strain,
+  "id" | "name" | "description" | "imageUrl" | "releaseDate" | "strainSlug"
+>;
+
 export default function StrainManager({
   producerId,
   initialStrains,
 }: {
   producerId: string;
-  initialStrains: Strain[];
+  initialStrains: StrainWithSlug[];
 }) {
-  const [strains, setStrains] = useState<Strain[]>(initialStrains);
-  const [editing, setEditing] = useState<Strain | null>(null);
+  const [strains, setStrains] = useState<StrainWithSlug[]>(initialStrains);
+  const [editing, setEditing] = useState<StrainWithSlug | null>(null);
 
   const refresh = async () => {
     const res = await fetch(`/api/strains?producerId=${producerId}`, {

--- a/src/components/UpcomingStrainList.tsx
+++ b/src/components/UpcomingStrainList.tsx
@@ -2,8 +2,13 @@
 import type { Strain } from "@prisma/client";
 import Image from "next/image";
 
+type StrainListItem = Pick<
+  Strain,
+  "id" | "name" | "description" | "imageUrl" | "releaseDate" | "strainSlug"
+>;
+
 interface UpcomingStrainListProps {
-  strains: Strain[];
+  strains: StrainListItem[];
 }
 
 export default function UpcomingStrainList({ strains }: UpcomingStrainListProps) {


### PR DESCRIPTION
## Summary
- add `strainSlug` field with autoincrement to `Strain`
- expose `strainSlug` in strain API endpoints
- include `strainSlug` in strain queries across drops and producer pages

## Testing
- `npx prisma migrate dev --name add-strain-slug` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68af9c151de8832db5245c20283178e3