### PR TITLE
feat: add strain review API routes

### DIFF
--- a/src/app/api/strain-reviews/[id]/route.ts
+++ b/src/app/api/strain-reviews/[id]/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prismadb";
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = createServerComponentClient({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.user?.email) {
+    return NextResponse.json(
+      { success: false, error: "Not authenticated" },
+      { status: 401 }
+    );
+  }
+
+  const prismaUser = await prisma.user.findUnique({
+    where: { email: session.user.email },
+  });
+
+  if (!prismaUser) {
+    return NextResponse.json(
+      { success: false, error: "User not found" },
+      { status: 404 }
+    );
+  }
+
+  const { id } = await params;
+
+  const existing = await prisma.strainReview.findUnique({ where: { id } });
+  if (!existing || existing.userId !== prismaUser.id) {
+    return NextResponse.json(
+      { success: false, error: "Not authorized" },
+      { status: 403 }
+    );
+  }
+
+  const body = await request.json();
+  const { comment, flavor, effect, smoke, imageUrl } = body as {
+    comment?: string;
+    flavor?: number;
+    effect?: number;
+    smoke?: number;
+    imageUrl?: string;
+  };
+
+  const newFlavor = flavor ?? existing.flavor;
+  const newEffect = effect ?? existing.effect;
+  const newSmoke = smoke ?? existing.smoke;
+  const aggregateRating = (newFlavor + newEffect + newSmoke) / 3;
+
+  const review = await prisma.strainReview.update({
+    where: { id },
+    data: {
+      comment,
+      flavor,
+      effect,
+      smoke,
+      imageUrl,
+      aggregateRating,
+    },
+  });
+
+  return NextResponse.json({ success: true, review });
+}

--- a/src/app/api/strain-reviews/route.ts
+++ b/src/app/api/strain-reviews/route.ts
@@ -1,0 +1,166 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prismadb";
+import { del } from "@vercel/blob";
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const strainId = searchParams.get("strainId");
+  const userId = searchParams.get("userId");
+
+  if (!strainId && !userId) {
+    return NextResponse.json(
+      { success: false, error: "Missing query" },
+      { status: 400 }
+    );
+  }
+
+  const where: any = {};
+  if (strainId) where.strainId = strainId;
+  if (userId) where.userId = userId;
+
+  const reviews = await prisma.strainReview.findMany({
+    where,
+    include: { user: true, producer: true },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  return NextResponse.json({ success: true, reviews });
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = createServerComponentClient({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.user?.email) {
+    return NextResponse.json(
+      { success: false, error: "Not authenticated" },
+      { status: 401 }
+    );
+  }
+
+  const prismaUser = await prisma.user.findUnique({
+    where: { email: session.user.email },
+  });
+
+  if (!prismaUser) {
+    return NextResponse.json(
+      { success: false, error: "User not found" },
+      { status: 404 }
+    );
+  }
+
+  const {
+    strainId,
+    producerId,
+    comment,
+    flavor,
+    effect,
+    smoke,
+    imageUrl,
+  } = (await request.json()) as {
+    strainId: string;
+    producerId: string;
+    comment?: string;
+    flavor: number;
+    effect: number;
+    smoke: number;
+    imageUrl?: string;
+  };
+
+  if (!strainId || !producerId) {
+    return NextResponse.json(
+      { success: false, error: "Missing strainId or producerId" },
+      { status: 400 }
+    );
+  }
+
+  const aggregateRating = (flavor + effect + smoke) / 3;
+
+  const review = await prisma.strainReview.upsert({
+    where: {
+      userId_strainId: {
+        userId: prismaUser.id,
+        strainId,
+      },
+    },
+    create: {
+      userId: prismaUser.id,
+      strainId,
+      producerId,
+      comment,
+      flavor,
+      effect,
+      smoke,
+      aggregateRating,
+      imageUrl,
+    },
+    update: {
+      comment,
+      flavor,
+      effect,
+      smoke,
+      aggregateRating,
+      imageUrl,
+    },
+  });
+
+  return NextResponse.json({ success: true, review });
+}
+
+export async function DELETE(request: NextRequest) {
+  const supabase = createServerComponentClient({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.user?.email) {
+    return NextResponse.json(
+      { success: false, error: "Not authenticated" },
+      { status: 401 }
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get("id");
+  if (!id) {
+    return NextResponse.json(
+      { success: false, error: "Missing id" },
+      { status: 400 }
+    );
+  }
+
+  const prismaUser = await prisma.user.findUnique({
+    where: { email: session.user.email },
+  });
+
+  if (!prismaUser) {
+    return NextResponse.json(
+      { success: false, error: "User not found" },
+      { status: 404 }
+    );
+  }
+
+  const review = await prisma.strainReview.findUnique({ where: { id } });
+  if (!review || review.userId !== prismaUser.id) {
+    return NextResponse.json(
+      { success: false, error: "Not authorized" },
+      { status: 403 }
+    );
+  }
+
+  if (review.imageUrl) {
+    try {
+      await del(review.imageUrl);
+    } catch (err) {
+      console.error("Failed to delete blob", err);
+    }
+  }
+
+  await prisma.strainReview.delete({ where: { id } });
+
+  return NextResponse.json({ success: true });
+}


### PR DESCRIPTION
## Summary
- add API handlers for strain reviews with CRUD operations
- support updating individual strain reviews

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build` *(fails: Type error in `src/app/admin/[slug]/page.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68afacffa8bc832d8e2d9a7b1d5dc68f