### PR TITLE
Add strain review page with rating components

### DIFF
--- a/src/app/(strain)/[producerSlug]/[strainSlug]/page.tsx
+++ b/src/app/(strain)/[producerSlug]/[strainSlug]/page.tsx
@@ -1,0 +1,118 @@
+import Image from "next/image";
+import Link from "next/link";
+import { prisma } from "@/lib/prismadb";
+import BackButton from "@/components/BackButton";
+import AddStrainReviewForm from "@/components/AddStrainReviewForm";
+import StrainReviewCard from "@/components/StrainReviewCard";
+import { createSupabaseServerClient } from "@/lib/supabaseServer";
+
+interface StrainPageProps {
+  params: Promise<{ producerSlug: string; strainSlug: string }>;
+}
+
+export default async function StrainPage({ params }: StrainPageProps) {
+  const { producerSlug, strainSlug } = await params;
+
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  let currentUserId: string | null = null;
+  if (session?.user?.email) {
+    const prismaUser = await prisma.user.findUnique({
+      where: { email: session.user.email },
+    });
+    currentUserId = prismaUser?.id || null;
+  }
+
+  const strain = await prisma.strain.findFirst({
+    where: { strainSlug: Number(strainSlug), producer: { slug: producerSlug } },
+    include: {
+      reviews: { include: { user: true }, orderBy: { updatedAt: "desc" } },
+      producer: true,
+    },
+  });
+
+  if (!strain) {
+    return (
+      <div className="container mx-auto p-4 mt-8 text-center">
+        <p className="text-xl text-red-500">Strain not found.</p>
+      </div>
+    );
+  }
+
+  const userReview = currentUserId
+    ? strain.reviews.find((r) => r.userId === currentUserId) ?? null
+    : null;
+  const otherReviews = strain.reviews.filter((r) => r.userId !== currentUserId);
+
+  const releaseDate = strain.releaseDate ? new Date(strain.releaseDate) : null;
+
+  return (
+    <div className="container mx-auto p-4 mt-8">
+      <BackButton />
+      <div className="flex flex-col md:flex-row items-start md:items-center mb-6 pb-6 border-b border-gray-300">
+        <div className="relative w-32 h-32 rounded overflow-hidden mr-4">
+          <Image
+            src={strain.imageUrl || "https://placehold.co/128"}
+            alt={strain.name}
+            fill
+            className="object-cover"
+          />
+        </div>
+        <div className="flex-grow text-left md:text-left">
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-800">
+            {strain.name}
+          </h1>
+          {releaseDate && (
+            <p className="text-gray-600 mt-2">
+              Released on {releaseDate.toLocaleDateString()}
+            </p>
+          )}
+          <p className="text-sm text-gray-500 mt-1">
+            by {" "}
+            <Link
+              href={`/producer/${strain.producer.slug ?? strain.producer.id}`}
+              className="underline hover:text-blue-600"
+            >
+              {strain.producer.name}
+            </Link>
+          </p>
+        </div>
+      </div>
+
+      {strain.description && (
+        <p className="text-gray-700 mb-8 whitespace-pre-wrap">
+          {strain.description}
+        </p>
+      )}
+
+      <div className="mt-8">
+        <h3 className="text-xl font-semibold mb-4">
+          Reviews ({strain.reviews.length})
+        </h3>
+        {userReview ? (
+          <StrainReviewCard
+            review={userReview}
+            currentUserId={currentUserId ?? undefined}
+            highlighted
+          />
+        ) : (
+          <AddStrainReviewForm
+            strainId={strain.id}
+            producerId={strain.producerId}
+          />
+        )}
+        {otherReviews.map((r) => (
+          <StrainReviewCard
+            key={r.id}
+            review={r}
+            currentUserId={currentUserId ?? undefined}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/drops/page.tsx
+++ b/src/app/drops/page.tsx
@@ -2,7 +2,6 @@
 import Link from "next/link";
 import Image from "next/image";
 import { prisma } from "@/lib/prismadb";
-import UpcomingStrainList from "@/components/UpcomingStrainList";
 import { Calendar, MapPin, TrendingUp, Clock } from "lucide-react";
 
 export default async function DropsPage() {

--- a/src/app/producer/[slug]/page.tsx
+++ b/src/app/producer/[slug]/page.tsx
@@ -241,7 +241,10 @@ export default async function ProducerProfilePage({
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-xl font-semibold">Strains</h3>
             </div>
-            <UpcomingStrainList strains={producer.strains} />
+            <UpcomingStrainList
+              strains={producer.strains}
+              producerSlug={producer.slug ?? producer.id}
+            />
           </div>
 
           {/* Chart Toggle Wrapper - replaces the direct RatingHistoryChart */}

--- a/src/components/AddStrainReviewForm.tsx
+++ b/src/components/AddStrainReviewForm.tsx
@@ -1,0 +1,163 @@
+"use client";
+import { useState, useEffect } from "react";
+import { supabase } from "@/lib/supabaseClient";
+import { useRouter } from "next/navigation";
+import UploadButton from "./UploadButton";
+import type { Session } from "@supabase/supabase-js";
+import { Star } from "lucide-react";
+
+function StarRating({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex">
+      {[1, 2, 3, 4, 5].map((n) => (
+        <Star
+          key={n}
+          className={`w-5 h-5 cursor-pointer ${
+            n <= value ? "text-yellow-400" : "text-gray-300"
+          }`}
+          fill={n <= value ? "currentColor" : "none"}
+          onClick={() => onChange(n)}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default function AddStrainReviewForm({
+  strainId,
+  producerId,
+}: {
+  strainId: string;
+  producerId: string;
+}) {
+  const [flavor, setFlavor] = useState(0);
+  const [effect, setEffect] = useState(0);
+  const [smoke, setSmoke] = useState(0);
+  const [comment, setComment] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [session, setSession] = useState<Session | null>(null);
+  const router = useRouter();
+
+  const MAX_SIZE = 5 * 1024 * 1024;
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    if (!f.type.startsWith("image/")) {
+      alert("Only images are allowed");
+      return;
+    }
+    if (f.size > MAX_SIZE) {
+      alert("Image is too large");
+      return;
+    }
+    setFile(f);
+  };
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+    const { data: listener } = supabase.auth.onAuthStateChange((_e, sess) =>
+      setSession(sess)
+    );
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const uploadFile = async () => {
+    if (!file) return null;
+    const form = new FormData();
+    form.append("file", file);
+    const res = await fetch("/api/upload", { method: "POST", body: form });
+    const data = await res.json();
+    return (data?.url as string) || null;
+  };
+
+  const submit = async () => {
+    if (!session?.user) {
+      router.push("/login?reason=review");
+      return;
+    }
+    const url = await uploadFile();
+    await fetch("/api/strain-reviews", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        strainId,
+        producerId,
+        comment: comment || undefined,
+        flavor,
+        effect,
+        smoke,
+        imageUrl: url || undefined,
+      }),
+    });
+    setComment("");
+    setFile(null);
+    setFlavor(0);
+    setEffect(0);
+    setSmoke(0);
+    router.refresh();
+  };
+
+  return (
+    <div className="bg-white shadow rounded-lg p-4 mb-6">
+      <div className="space-y-4">
+        <div className="flex items-center space-x-2">
+          <span className="w-20">Flavor</span>
+          <StarRating value={flavor} onChange={setFlavor} />
+        </div>
+        <div className="flex items-center space-x-2">
+          <span className="w-20">Effect</span>
+          <StarRating value={effect} onChange={setEffect} />
+        </div>
+        <div className="flex items-center space-x-2">
+          <span className="w-20">Smoke</span>
+          <StarRating value={smoke} onChange={setSmoke} />
+        </div>
+        <textarea
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          className="w-full border rounded-md p-2"
+          placeholder="Leave a review (optional)"
+        />
+        <UploadButton
+          onChange={handleFileChange}
+          disabled={!session?.user}
+          onClick={() => {
+            if (!session?.user) router.push("/login?reason=review");
+          }}
+        />
+        {file && (
+          <div className="relative inline-block ml-2">
+            <img
+              src={URL.createObjectURL(file)}
+              alt="preview"
+              className="w-20 h-20 object-cover rounded"
+            />
+            <button
+              type="button"
+              onClick={() => setFile(null)}
+              className="absolute -top-1 -right-1 bg-white rounded-full text-xs px-1 border"
+            >
+              x
+            </button>
+          </div>
+        )}
+        <button
+          onClick={submit}
+          className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 ml-2 rounded-md"
+        >
+          Submit
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/StrainReviewCard.tsx
+++ b/src/components/StrainReviewCard.tsx
@@ -1,0 +1,298 @@
+"use client";
+import { useState } from "react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Leaf, Trash2, FilePenLine, Star } from "lucide-react";
+import UploadButton from "./UploadButton";
+import { deleteBlob } from "@/utils/blob";
+
+export interface StrainReview {
+  id: string;
+  comment: string | null;
+  flavor: number;
+  effect: number;
+  smoke: number;
+  aggregateRating: number;
+  imageUrl?: string | null;
+  user: {
+    id: string;
+    name: string | null;
+    email: string;
+    username: string | null;
+    profilePicUrl: string | null;
+  };
+  userId: string;
+  producerId: string;
+  strainId: string;
+  updatedAt: string | Date;
+}
+
+function StarDisplay({ rating }: { rating: number }) {
+  return (
+    <div className="flex">
+      {[1, 2, 3, 4, 5].map((n) => (
+        <Star
+          key={n}
+          className={`w-4 h-4 ${n <= rating ? "text-yellow-400" : "text-gray-300"}`}
+          fill={n <= rating ? "currentColor" : "none"}
+        />
+      ))}
+    </div>
+  );
+}
+
+function StarRating({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex">
+      {[1, 2, 3, 4, 5].map((n) => (
+        <Star
+          key={n}
+          className={`w-5 h-5 cursor-pointer ${
+            n <= value ? "text-yellow-400" : "text-gray-300"
+          }`}
+          fill={n <= value ? "currentColor" : "none"}
+          onClick={() => onChange(n)}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default function StrainReviewCard({
+  review,
+  currentUserId,
+  highlighted,
+}: {
+  review: StrainReview;
+  currentUserId?: string;
+  highlighted?: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [comment, setComment] = useState(review.comment || "");
+  const [flavor, setFlavor] = useState(review.flavor);
+  const [effect, setEffect] = useState(review.effect);
+  const [smoke, setSmoke] = useState(review.smoke);
+  const [imageUrl, setImageUrl] = useState<string | null>(review.imageUrl || null);
+  const [expandedImage, setExpandedImage] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const router = useRouter();
+
+  const MAX_SIZE = 5 * 1024 * 1024;
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      alert("Only images are allowed");
+      return;
+    }
+    if (file.size > MAX_SIZE) {
+      alert("Image is too large");
+      return;
+    }
+    setUploading(true);
+    const form = new FormData();
+    form.append("file", file);
+    const res = await fetch("/api/upload", { method: "POST", body: form });
+    const data = await res.json();
+    if (data?.url) {
+      setImageUrl(data.url as string);
+    }
+    setUploading(false);
+  };
+
+  const save = async () => {
+    await fetch(`/api/strain-reviews/${review.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ comment, flavor, effect, smoke, imageUrl }),
+    });
+    setEditing(false);
+    router.refresh();
+  };
+
+  const removeImage = async () => {
+    if (imageUrl) await deleteBlob(imageUrl);
+    setImageUrl(null);
+  };
+
+  const deleteReview = async () => {
+    await fetch(`/api/strain-reviews?id=${review.id}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    router.refresh();
+  };
+
+  if (editing) {
+    return (
+      <div className="bg-white shadow rounded-lg p-4 mb-4">
+        <div className="space-y-4">
+          <div className="flex items-center space-x-2">
+            <span className="w-20">Flavor</span>
+            <StarRating value={flavor} onChange={setFlavor} />
+          </div>
+          <div className="flex items-center space-x-2">
+            <span className="w-20">Effect</span>
+            <StarRating value={effect} onChange={setEffect} />
+          </div>
+          <div className="flex items-center space-x-2">
+            <span className="w-20">Smoke</span>
+            <StarRating value={smoke} onChange={setSmoke} />
+          </div>
+          <textarea
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            className="w-full border rounded-md p-2"
+          />
+          {imageUrl && (
+            <div className="relative">
+              <Image
+                src={imageUrl}
+                alt="review image"
+                width={80}
+                height={80}
+                className="object-cover rounded"
+              />
+              <button
+                onClick={removeImage}
+                className="absolute -top-1 -right-1 bg-white rounded-full text-xs px-1 border"
+              >
+                x
+              </button>
+            </div>
+          )}
+          <UploadButton onChange={handleFileChange} />
+          {uploading && (
+            <p className="text-sm text-gray-500">Uploading...</p>
+          )}
+          <button
+            onClick={save}
+            className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded-md"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-gray-50 rounded-lg p-4 mb-4 shadow">
+      <div className="flex justify-between mb-2">
+        <div className="flex items-center">
+          {review.user.profilePicUrl ? (
+            <Link href={`/profile/${review.user.username ?? review.user.id}`}>
+              <img
+                src={review.user.profilePicUrl}
+                alt="profile"
+                className="w-10 h-10 rounded-full object-cover"
+              />
+            </Link>
+          ) : (
+            <div className="w-10 h-10 rounded-full bg-gray-300 flex items-center justify-center">
+              <Leaf className="w-5 h-5 text-white" />
+            </div>
+          )}
+          <div className="ml-2">
+            <Link
+              href={`/profile/${review.user.username ?? review.user.id}`}
+              className={`font-semibold ${
+                highlighted ? "text-green-600" : "hover:underline"
+              }`}
+            >
+              {review.user.username || review.user.name || review.user.email}
+            </Link>
+            <p className="text-xs text-gray-500">
+              Last edited {new Date(review.updatedAt).toLocaleString()}
+            </p>
+          </div>
+        </div>
+        {currentUserId === review.userId && (
+          <div className="flex items-center space-x-2">
+            <button
+              onClick={() => setEditing(true)}
+              className="text-blue-600 hover:text-blue-800"
+              aria-label="Edit review"
+            >
+              <FilePenLine className="w-4 h-4" />
+            </button>
+            <button
+              onClick={deleteReview}
+              className="text-red-600 hover:text-red-800"
+              aria-label="Delete review"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+      <div className="mb-2 text-sm space-y-1">
+        <div className="flex items-center gap-2">
+          <span className="w-16">Flavor:</span>
+          <StarDisplay rating={review.flavor} />
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="w-16">Effect:</span>
+          <StarDisplay rating={review.effect} />
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="w-16">Smoke:</span>
+          <StarDisplay rating={review.smoke} />
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="w-16 font-semibold">Overall:</span>
+          <StarDisplay rating={Math.round(review.aggregateRating)} />
+          <span className="text-gray-600 text-xs">
+            {review.aggregateRating.toFixed(1)}
+          </span>
+        </div>
+      </div>
+      {review.comment && <p className="mb-2 whitespace-pre-wrap">{review.comment}</p>}
+      {imageUrl && (
+        <div className="flex flex-wrap gap-2">
+          <Image
+            src={imageUrl}
+            alt="review image"
+            width={80}
+            height={80}
+            className="object-cover rounded cursor-pointer"
+            onClick={() => setExpandedImage(imageUrl)}
+          />
+        </div>
+      )}
+      {expandedImage && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/75"
+          onClick={() => setExpandedImage(null)}
+        >
+          <button
+            aria-label="Close image"
+            className="absolute top-4 right-4 text-white text-3xl"
+            onClick={(e) => {
+              e.stopPropagation();
+              setExpandedImage(null);
+            }}
+          >
+            &times;
+          </button>
+          <Image
+            src={expandedImage}
+            alt="expanded review image"
+            width={800}
+            height={800}
+            className="max-h-[90vh] w-auto h-auto object-contain rounded"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/UpcomingStrainList.tsx
+++ b/src/components/UpcomingStrainList.tsx
@@ -1,6 +1,7 @@
 // src/components/UpcomingStrainList.tsx
 import type { Strain } from "@prisma/client";
 import Image from "next/image";
+import Link from "next/link";
 
 type StrainListItem = Pick<
   Strain,
@@ -9,9 +10,13 @@ type StrainListItem = Pick<
 
 interface UpcomingStrainListProps {
   strains: StrainListItem[];
+  producerSlug: string;
 }
 
-export default function UpcomingStrainList({ strains }: UpcomingStrainListProps) {
+export default function UpcomingStrainList({
+  strains,
+  producerSlug,
+}: UpcomingStrainListProps) {
   if (strains.length === 0) {
     return <p className="text-gray-500 italic">No strains.</p>;
   }
@@ -25,26 +30,29 @@ export default function UpcomingStrainList({ strains }: UpcomingStrainListProps)
         const hasDropped = releaseDate ? releaseDate < new Date() : false;
 
         return (
-          <li
-            key={strain.id}
-            className="bg-white shadow rounded p-4 flex items-center space-x-4"
-          >
-            <div className="relative w-16 h-16 flex-shrink-0">
-              <Image
-                src={strain.imageUrl || "https://placehold.co/64"}
-                alt={strain.name}
-                fill
-                className="object-cover rounded"
-              />
-            </div>
-            <div>
-              <h3 className="text-lg font-semibold">{strain.name}</h3>
-              {releaseDate && (
-                <p className="text-sm text-gray-500">
-                  {hasDropped ? "Dropped on" : "Drops on"} {releaseDate.toLocaleDateString()}
-                </p>
-              )}
-            </div>
+          <li key={strain.id} className="bg-white shadow rounded p-4">
+            <Link
+              href={`/${producerSlug}/${strain.strainSlug}`}
+              className="flex items-center space-x-4"
+            >
+              <div className="relative w-16 h-16 flex-shrink-0">
+                <Image
+                  src={strain.imageUrl || "https://placehold.co/64"}
+                  alt={strain.name}
+                  fill
+                  className="object-cover rounded"
+                />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold">{strain.name}</h3>
+                {releaseDate && (
+                  <p className="text-sm text-gray-500">
+                    {hasDropped ? "Dropped on" : "Drops on"}{" "}
+                    {releaseDate.toLocaleDateString()}
+                  </p>
+                )}
+              </div>
+            </Link>
           </li>
         );
       })}


### PR DESCRIPTION
## Summary
- add dynamic strain page at `/:producerSlug/:strainSlug` with Prisma-powered review fetching
- create `AddStrainReviewForm` and `StrainReviewCard` for posting and editing strain reviews with three rating categories
- link strains via `/[producerSlug]/[strainSlug]` through updated `UpcomingStrainList`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68afb08268b0832da8bf8cf0475a5a29