### PR TITLE
feat: add reusable StrainCard and wire up review counts

### DIFF
--- a/src/app/drops/[producerSlug]/page.tsx
+++ b/src/app/drops/[producerSlug]/page.tsx
@@ -1,12 +1,10 @@
 // src/app/drops/[producerSlug]/page.tsx
 import Link from "next/link";
 import Image from "next/image";
+import StrainCard from "@/components/StrainCard";
 import { prisma } from "@/lib/prismadb";
 import {
   Calendar,
-  ChevronLeft,
-  ChevronRight,
-  MapPin,
   Clock,
   Package,
   ArrowLeft,
@@ -44,6 +42,7 @@ export default async function DropsByProducerPage({
           imageUrl: true,
           releaseDate: true,
           strainSlug: true,
+          _count: { select: { reviews: true } },
         },
       },
     },
@@ -354,54 +353,25 @@ export default async function DropsByProducerPage({
               </h3>
               <div className="grid gap-4">
                 {producer.strains.map((strain) => (
-                  <div
+                  <StrainCard
                     key={strain.id}
-                    className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden hover:shadow-md transition-shadow"
+                    strain={strain}
+                    producerSlug={producer.slug ?? producer.id}
                   >
-                    <div className="flex flex-col sm:flex-row">
-                      {/* Strain Image */}
-                      <div className="w-full sm:w-32 h-32 sm:h-24 bg-gradient-to-br from-green-100 to-emerald-200 flex items-center justify-center flex-shrink-0">
-                        {strain.imageUrl ? (
-                          <Image
-                            src={strain.imageUrl}
-                            alt={strain.name}
-                            width={128}
-                            height={96}
-                            className="w-full h-full object-cover"
-                          />
-                        ) : (
-                          <Package className="w-8 h-8 text-green-500" />
-                        )}
-                      </div>
-
-                      {/* Strain Info */}
-                      <div className="flex-1 p-4">
-                        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                          <div>
-                            <h4 className="text-lg font-semibold text-gray-900 mb-1">
-                              {strain.name}
-                            </h4>
-                            {strain.description && (
-                              <p className="text-sm text-gray-600 line-clamp-2">
-                                {strain.description}
-                              </p>
-                            )}
-                          </div>
-
-                          <div className="flex items-center gap-3 text-sm text-gray-500">
-                            <div className="flex items-center gap-1">
-                              <Clock className="w-4 h-4" />
-                              <span>
-                                {strain.releaseDate
-                                  ? formatDate(strain.releaseDate)
-                                  : "TBD"}
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
+                    {strain.description && (
+                      <p className="text-sm text-gray-600 line-clamp-2">
+                        {strain.description}
+                      </p>
+                    )}
+                    <div className="flex items-center gap-3 text-sm text-gray-500 mt-1">
+                      <Clock className="w-4 h-4" />
+                      <span>
+                        {strain.releaseDate
+                          ? formatDate(strain.releaseDate)
+                          : "TBD"}
+                      </span>
                     </div>
-                  </div>
+                  </StrainCard>
                 ))}
               </div>
             </div>

--- a/src/app/drops/page.tsx
+++ b/src/app/drops/page.tsx
@@ -1,8 +1,9 @@
 // src/app/drops/page.tsx
 import Link from "next/link";
 import Image from "next/image";
+import StrainCard from "@/components/StrainCard";
 import { prisma } from "@/lib/prismadb";
-import { Calendar, MapPin, TrendingUp, Clock } from "lucide-react";
+import { Calendar, TrendingUp, Clock } from "lucide-react";
 
 export default async function DropsPage() {
   const now = new Date();
@@ -18,6 +19,7 @@ export default async function DropsPage() {
       imageUrl: true,
       releaseDate: true,
       strainSlug: true,
+      _count: { select: { reviews: true } },
       producer: {
         select: {
           id: true,
@@ -171,32 +173,42 @@ export default async function DropsPage() {
                   {/* Drop Timeline */}
                   <div className="p-6 bg-gray-50/50">
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                      {strains.slice(0, 3).map((strain) => {
-                        if (!strain.releaseDate) return null;
-                        const daysUntil = getDaysUntilDrop(strain.releaseDate);
-                        return (
-                          <div key={strain.id} className="bg-white rounded-xl p-4 border border-gray-100">
-                            <div className="flex items-start justify-between mb-2">
-                              <h4 className="font-semibold text-gray-900 truncate flex-1 mr-2">
-                                {strain.name}
-                              </h4>
-                              <div className={`px-2 py-1 rounded-full text-xs font-medium ${
-                                daysUntil === 0 
-                                  ? 'bg-red-100 text-red-600' 
-                                  : daysUntil === 1 
-                                  ? 'bg-orange-100 text-orange-600'
-                                  : 'bg-blue-100 text-blue-600'
-                              }`}>
-                                {daysUntil === 0 ? 'Today' : daysUntil === 1 ? 'Tomorrow' : `${daysUntil}d`}
+                      {strains
+                        .slice(0, 3)
+                        .map((strain) => {
+                          if (!strain.releaseDate) return null;
+                          const daysUntil = getDaysUntilDrop(strain.releaseDate);
+                          return (
+                            <StrainCard
+                              key={strain.id}
+                              strain={strain}
+                              producerSlug={producer.slug ?? producer.id}
+                            >
+                              <div className="flex items-center justify-between mt-1">
+                                <div className="flex items-center gap-2 text-sm text-gray-600">
+                                  <Calendar className="w-4 h-4" />
+                                  <span>{formatDate(strain.releaseDate)}</span>
+                                </div>
+                                <div
+                                  className={`px-2 py-1 rounded-full text-xs font-medium ${
+                                    daysUntil === 0
+                                      ? "bg-red-100 text-red-600"
+                                      : daysUntil === 1
+                                      ? "bg-orange-100 text-orange-600"
+                                      : "bg-blue-100 text-blue-600"
+                                  }`}
+                                >
+                                  {daysUntil === 0
+                                    ? "Today"
+                                    : daysUntil === 1
+                                    ? "Tomorrow"
+                                    : `${daysUntil}d`}
+                                </div>
                               </div>
-                            </div>
-                            <div className="flex items-center gap-2 text-sm text-gray-600">
-                              <Calendar className="w-4 h-4" />
-                              <span>{formatDate(strain.releaseDate)}</span>
-                            </div>
-                          </div>
-                        );
-                      }).filter(Boolean)}
+                            </StrainCard>
+                          );
+                        })
+                        .filter(Boolean)}
                     </div>
                     
                     {strains.length > 3 && (

--- a/src/app/producer/[slug]/page.tsx
+++ b/src/app/producer/[slug]/page.tsx
@@ -57,6 +57,7 @@ export default async function ProducerProfilePage({
           imageUrl: true,
           releaseDate: true,
           strainSlug: true,
+          _count: { select: { reviews: true } },
         },
       },
     },

--- a/src/components/StrainCard.tsx
+++ b/src/components/StrainCard.tsx
@@ -1,0 +1,48 @@
+// src/components/StrainCard.tsx
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { MessageCircle } from "lucide-react";
+import type { Strain } from "@prisma/client";
+import type { ReactNode } from "react";
+
+interface StrainCardProps {
+  strain: Pick<
+    Strain,
+    "id" | "name" | "imageUrl" | "strainSlug"
+  > & { _count?: { reviews: number } };
+  producerSlug: string;
+  children?: ReactNode;
+}
+
+export default function StrainCard({
+  strain,
+  producerSlug,
+  children,
+}: StrainCardProps) {
+  return (
+    <Link
+      href={`/${producerSlug}/${strain.strainSlug}`}
+      className="flex items-center space-x-4 bg-white shadow rounded p-4 hover:bg-gray-50 transition"
+    >
+      <div className="relative w-16 h-16 flex-shrink-0">
+        <Image
+          src={strain.imageUrl || "https://placehold.co/64"}
+          alt={strain.name}
+          fill
+          className="object-cover rounded"
+        />
+      </div>
+      <div className="flex-1">
+        <h3 className="text-lg font-semibold">{strain.name}</h3>
+        {children}
+      </div>
+      <div className="flex items-center text-sm text-gray-600">
+        <MessageCircle className="w-4 h-4 mr-1" />
+        {strain._count?.reviews ?? 0}
+      </div>
+    </Link>
+  );
+}
+

--- a/src/components/UpcomingStrainList.tsx
+++ b/src/components/UpcomingStrainList.tsx
@@ -1,12 +1,11 @@
 // src/components/UpcomingStrainList.tsx
 import type { Strain } from "@prisma/client";
-import Image from "next/image";
-import Link from "next/link";
+import StrainCard from "./StrainCard";
 
 type StrainListItem = Pick<
   Strain,
   "id" | "name" | "description" | "imageUrl" | "releaseDate" | "strainSlug"
->;
+> & { _count?: { reviews: number } };
 
 interface UpcomingStrainListProps {
   strains: StrainListItem[];
@@ -30,29 +29,15 @@ export default function UpcomingStrainList({
         const hasDropped = releaseDate ? releaseDate < new Date() : false;
 
         return (
-          <li key={strain.id} className="bg-white shadow rounded p-4">
-            <Link
-              href={`/${producerSlug}/${strain.strainSlug}`}
-              className="flex items-center space-x-4"
-            >
-              <div className="relative w-16 h-16 flex-shrink-0">
-                <Image
-                  src={strain.imageUrl || "https://placehold.co/64"}
-                  alt={strain.name}
-                  fill
-                  className="object-cover rounded"
-                />
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold">{strain.name}</h3>
-                {releaseDate && (
-                  <p className="text-sm text-gray-500">
-                    {hasDropped ? "Dropped on" : "Drops on"}{" "}
-                    {releaseDate.toLocaleDateString()}
-                  </p>
-                )}
-              </div>
-            </Link>
+          <li key={strain.id}>
+            <StrainCard strain={strain} producerSlug={producerSlug}>
+              {releaseDate && (
+                <p className="text-sm text-gray-500">
+                  {hasDropped ? "Dropped on" : "Drops on"}{" "}
+                  {releaseDate.toLocaleDateString()}
+                </p>
+              )}
+            </StrainCard>
           </li>
         );
       })}


### PR DESCRIPTION
## Summary
- add `StrainCard` component for displaying strain info and review counts
- refactor upcoming listings and drop pages to use `StrainCard`
- load review counts for strains via Prisma `_count`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for interactive ESLint configuration)*


------
https://chatgpt.com/codex/tasks/task_e_68afb76c2ed8832dabac1389ae2c8401