### PR TITLE
Add strain review display on profiles and strain slug editing

### DIFF
--- a/prisma/migrations/20250826120000_add_strain_slug/migration.sql
+++ b/prisma/migrations/20250826120000_add_strain_slug/migration.sql
@@ -1,3 +1,2 @@
--- Add strainSlug column to Strain
-ALTER TABLE "Strain" ADD COLUMN "strainSlug" SERIAL;
+ALTER TABLE "Strain" ADD COLUMN "strainSlug" TEXT NOT NULL DEFAULT gen_random_uuid();
 CREATE UNIQUE INDEX "Strain_strainSlug_key" ON "Strain"("strainSlug");

--- a/prisma/migrations/20250826120000_add_strain_slug/migration.sql
+++ b/prisma/migrations/20250826120000_add_strain_slug/migration.sql
@@ -1,2 +1,3 @@
-ALTER TABLE "Strain" ADD COLUMN "strainSlug" TEXT NOT NULL DEFAULT gen_random_uuid();
+-- Add strainSlug column to Strain
+ALTER TABLE "Strain" ADD COLUMN "strainSlug" SERIAL;
 CREATE UNIQUE INDEX "Strain_strainSlug_key" ON "Strain"("strainSlug");

--- a/prisma/migrations/20250910120000_convert_strain_slug_to_text/migration.sql
+++ b/prisma/migrations/20250910120000_convert_strain_slug_to_text/migration.sql
@@ -1,0 +1,6 @@
+-- Convert strainSlug from serial integer to text with random default
+ALTER TABLE "Strain" ALTER COLUMN "strainSlug" DROP DEFAULT;
+ALTER TABLE "Strain" ALTER COLUMN "strainSlug" TYPE TEXT USING "strainSlug"::TEXT;
+DROP SEQUENCE IF EXISTS "Strain_strainSlug_seq";
+UPDATE "Strain" SET "strainSlug" = gen_random_uuid();
+ALTER TABLE "Strain" ALTER COLUMN "strainSlug" SET DEFAULT gen_random_uuid();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -111,7 +111,7 @@ model ProducerAdmin {
 
 model Strain {
   id           String         @id @default(cuid())
-  strainSlug   Int            @unique @default(autoincrement())
+  strainSlug   String         @unique @default(cuid())
   name         String
   description  String?
   releaseDate  DateTime?

--- a/src/app/api/strains/[id]/route.ts
+++ b/src/app/api/strains/[id]/route.ts
@@ -8,7 +8,7 @@ interface UpdateStrainBody {
   description?: string | null;
   imageUrl?: string | null;
   releaseDate?: string | null;
-  strainSlug?: number;
+  strainSlug?: string;
 }
 
 async function canManageProducer(

--- a/src/app/api/strains/[id]/route.ts
+++ b/src/app/api/strains/[id]/route.ts
@@ -8,6 +8,7 @@ interface UpdateStrainBody {
   description?: string | null;
   imageUrl?: string | null;
   releaseDate?: string | null;
+  strainSlug?: number;
 }
 
 async function canManageProducer(
@@ -100,6 +101,7 @@ export async function PUT(
         description: body.description,
         imageUrl: body.imageUrl,
         releaseDate: body.releaseDate ? new Date(body.releaseDate) : body.releaseDate,
+        strainSlug: body.strainSlug,
       },
       select: {
         id: true,

--- a/src/app/api/strains/route.ts
+++ b/src/app/api/strains/route.ts
@@ -9,7 +9,7 @@ interface CreateStrainBody {
   description?: string;
   imageUrl?: string;
   releaseDate?: string | null;
-  strainSlug?: number;
+  strainSlug?: string;
 }
 
 async function canManageProducer(

--- a/src/app/api/strains/route.ts
+++ b/src/app/api/strains/route.ts
@@ -9,6 +9,7 @@ interface CreateStrainBody {
   description?: string;
   imageUrl?: string;
   releaseDate?: string | null;
+  strainSlug?: number;
 }
 
 async function canManageProducer(
@@ -97,6 +98,7 @@ export async function POST(request: NextRequest) {
         description: body.description,
         imageUrl: body.imageUrl,
         releaseDate: body.releaseDate ? new Date(body.releaseDate) : undefined,
+        strainSlug: body.strainSlug,
       },
       select: {
         id: true,

--- a/src/app/producer/[slug]/[strainSlug]/page.tsx
+++ b/src/app/producer/[slug]/[strainSlug]/page.tsx
@@ -7,11 +7,11 @@ import StrainReviewCard from "@/components/StrainReviewCard";
 import { createSupabaseServerClient } from "@/lib/supabaseServer";
 
 interface StrainPageProps {
-  params: Promise<{ producerSlug: string; strainSlug: string }>;
+  params: Promise<{ slug: string; strainSlug: string }>;
 }
 
 export default async function StrainPage({ params }: StrainPageProps) {
-  const { producerSlug, strainSlug } = await params;
+  const { slug: producerSlug, strainSlug } = await params;
 
   const supabase = createSupabaseServerClient();
   const {
@@ -27,7 +27,7 @@ export default async function StrainPage({ params }: StrainPageProps) {
   }
 
   const strain = await prisma.strain.findFirst({
-    where: { strainSlug: Number(strainSlug), producer: { slug: producerSlug } },
+    where: { strainSlug, producer: { slug: producerSlug } },
     include: {
       StrainReview: {
         include: { user: true },

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -50,7 +50,7 @@ export default async function ProfilePage({
         include: { producer: true, user: true },
         orderBy: { updatedAt: "desc" },
       },
-      strainReviews: {
+      StrainReview: {
         include: { strain: { include: { producer: true } } },
         orderBy: { updatedAt: "desc" },
       },
@@ -68,7 +68,7 @@ export default async function ProfilePage({
           include: { producer: true, user: true },
           orderBy: { updatedAt: "desc" },
         },
-        strainReviews: {
+        StrainReview: {
           include: { strain: { include: { producer: true } } },
           orderBy: { updatedAt: "desc" },
         },
@@ -249,11 +249,11 @@ export default async function ProfilePage({
 
       <div className="bg-white shadow-xl rounded-lg p-6 md:p-8 max-w-6xl mx-auto">
         <h2 className="text-2xl font-bold mb-6">
-          Reviewed Strains ({user.strainReviews.length})
+          Reviewed Strains ({user.StrainReview.length})
         </h2>
-        {user.strainReviews.length > 0 ? (
+        {user.StrainReview.length > 0 ? (
           <div className="space-y-6">
-            {user.strainReviews.map((review) => (
+            {user.StrainReview.map((review) => (
               <div key={review.id}>
                 <Link
                   href={`/producer/${review.strain.producer.slug}/${review.strain.strainSlug}`}

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -256,7 +256,7 @@ export default async function ProfilePage({
             {user.strainReviews.map((review) => (
               <div key={review.id}>
                 <Link
-                  href={`/${review.strain.producer.slug}/${review.strain.strainSlug}`}
+                  href={`/producer/${review.strain.producer.slug}/${review.strain.strainSlug}`}
                   className="text-lg font-semibold hover:underline"
                 >
                   {review.strain.name}

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -51,7 +51,18 @@ export default async function ProfilePage({
         orderBy: { updatedAt: "desc" },
       },
       StrainReview: {
-        include: { strain: { include: { producer: true } } },
+        include: {
+          strain: { include: { producer: true } },
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              username: true,
+              profilePicUrl: true,
+            },
+          },
+        },
         orderBy: { updatedAt: "desc" },
       },
     },
@@ -69,7 +80,18 @@ export default async function ProfilePage({
           orderBy: { updatedAt: "desc" },
         },
         StrainReview: {
-          include: { strain: { include: { producer: true } } },
+          include: {
+            strain: { include: { producer: true } },
+            user: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+                username: true,
+                profilePicUrl: true,
+              },
+            },
+          },
           orderBy: { updatedAt: "desc" },
         },
       },

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -4,6 +4,8 @@ import CommentCard from "@/components/CommentCard";
 import ProfileImageUpload from "@/components/ProfileImageUpload";
 import NotificationOptInToggle from "@/components/NotificationOptInToggle";
 import BackButton from "@/components/BackButton";
+import StrainReviewCard from "@/components/StrainReviewCard";
+import Link from "next/link";
 import { prisma } from "@/lib/prismadb";
 import { cookies } from "next/headers";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
@@ -48,6 +50,10 @@ export default async function ProfilePage({
         include: { producer: true, user: true },
         orderBy: { updatedAt: "desc" },
       },
+      strainReviews: {
+        include: { strain: { include: { producer: true } } },
+        orderBy: { updatedAt: "desc" },
+      },
     },
   });
 
@@ -60,6 +66,10 @@ export default async function ProfilePage({
         },
         comments: {
           include: { producer: true, user: true },
+          orderBy: { updatedAt: "desc" },
+        },
+        strainReviews: {
+          include: { strain: { include: { producer: true } } },
           orderBy: { updatedAt: "desc" },
         },
       },
@@ -206,7 +216,7 @@ export default async function ProfilePage({
       </div>
 
       {/* Rated Producers Section */}
-      <div className="bg-white shadow-xl rounded-lg p-6 md:p-8 max-w-6xl mx-auto">
+      <div className="bg-white shadow-xl rounded-lg p-6 md:p-8 max-w-6xl mx-auto mb-8">
         <h2 className="text-2xl font-bold text-gray-800 mb-6 pb-3 border-b border-gray-300">
           Rated Producers ({likedProducers.length})
         </h2>
@@ -234,6 +244,32 @@ export default async function ProfilePage({
           </div>
         ) : (
           <p className="text-gray-600 text-center py-8">No rated producers yet.</p>
+        )}
+      </div>
+
+      <div className="bg-white shadow-xl rounded-lg p-6 md:p-8 max-w-6xl mx-auto">
+        <h2 className="text-2xl font-bold mb-6">
+          Reviewed Strains ({user.strainReviews.length})
+        </h2>
+        {user.strainReviews.length > 0 ? (
+          <div className="space-y-6">
+            {user.strainReviews.map((review) => (
+              <div key={review.id}>
+                <Link
+                  href={`/${review.strain.producer.slug}/${review.strain.strainSlug}`}
+                  className="text-lg font-semibold hover:underline"
+                >
+                  {review.strain.name}
+                </Link>
+                <StrainReviewCard
+                  review={review}
+                  currentUserId={currentViewerId}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-gray-600 text-center py-8">No strain reviews yet.</p>
         )}
       </div>
     </div>

--- a/src/components/AddStrainForm.tsx
+++ b/src/components/AddStrainForm.tsx
@@ -40,7 +40,7 @@ export default function AddStrainForm({
       description,
       imageUrl,
       releaseDate: releaseDate || null,
-      strainSlug: strainSlug ? Number(strainSlug) : undefined,
+      strainSlug: strainSlug || undefined,
     };
     if (strain) {
       await fetch(`/api/strains/${strain.id}`, {
@@ -74,7 +74,7 @@ export default function AddStrainForm({
         className="border p-2 rounded w-full"
       />
       <input
-        type="number"
+        type="text"
         placeholder="Strain slug"
         value={strainSlug}
         onChange={(e) => setStrainSlug(e.target.value)}

--- a/src/components/AddStrainForm.tsx
+++ b/src/components/AddStrainForm.tsx
@@ -20,6 +20,9 @@ export default function AddStrainForm({
   const [name, setName] = useState(strain?.name ?? "");
   const [description, setDescription] = useState(strain?.description ?? "");
   const [imageUrl, setImageUrl] = useState<string | null>(strain?.imageUrl ?? null);
+  const [strainSlug, setStrainSlug] = useState(
+    strain?.strainSlug ? String(strain.strainSlug) : "",
+  );
   function formatInputDate(date?: string | Date | null) {
     if (!date) return "";
     const d = typeof date === "string" ? new Date(date) : date;
@@ -37,6 +40,7 @@ export default function AddStrainForm({
       description,
       imageUrl,
       releaseDate: releaseDate || null,
+      strainSlug: strainSlug ? Number(strainSlug) : undefined,
     };
     if (strain) {
       await fetch(`/api/strains/${strain.id}`, {
@@ -56,6 +60,7 @@ export default function AddStrainForm({
     setName("");
     setDescription("");
     setImageUrl(null);
+    setStrainSlug("");
     onSaved ? onSaved() : window.location.reload();
   };
 
@@ -66,6 +71,13 @@ export default function AddStrainForm({
         placeholder="Strain name"
         value={name}
         onChange={(e) => setName(e.target.value)}
+        className="border p-2 rounded w-full"
+      />
+      <input
+        type="number"
+        placeholder="Strain slug"
+        value={strainSlug}
+        onChange={(e) => setStrainSlug(e.target.value)}
         className="border p-2 rounded w-full"
       />
       <textarea

--- a/src/components/StrainCard.tsx
+++ b/src/components/StrainCard.tsx
@@ -23,7 +23,7 @@ export default function StrainCard({
 }: StrainCardProps) {
   return (
     <Link
-      href={`/${producerSlug}/${strain.strainSlug}`}
+      href={`/producer/${producerSlug}/${strain.strainSlug}`}
       className="flex items-center space-x-4 bg-white shadow rounded p-4 hover:bg-gray-50 transition"
     >
       <div className="relative w-16 h-16 flex-shrink-0">


### PR DESCRIPTION
## Summary
- show strain reviews on profile pages and link to strain pages
- allow editing strainSlug when creating or updating strains
- support strainSlug in strain API routes

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68afc85d66f8832d93f8ac7f1bf6b3d9