### PR TITLE
feat: show strain review averages

### DIFF
--- a/src/app/drops/[producerSlug]/page.tsx
+++ b/src/app/drops/[producerSlug]/page.tsx
@@ -44,6 +44,7 @@ export default async function DropsByProducerPage({
           releaseDate: true,
           strainSlug: true,
           _count: { select: { StrainReview: true } },
+          StrainReview: { select: { aggregateRating: true } },
         },
       },
     },
@@ -75,6 +76,15 @@ export default async function DropsByProducerPage({
   }
 
   // Calendar logic
+  const strains = producer.strains.map(({ StrainReview, ...rest }) => {
+    const avg =
+      StrainReview.length > 0
+        ? StrainReview.reduce((sum, r) => sum + r.aggregateRating, 0) /
+          StrainReview.length
+        : null;
+    return { ...rest, avgRating: avg };
+  });
+
   const currentDate = new Date();
   const currentYear = currentDate.getFullYear();
   const currentMonth = currentDate.getMonth();
@@ -103,8 +113,8 @@ export default async function DropsByProducerPage({
   const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
   // Group strains by date
-  const strainsByDate = producer.strains.reduce<
-    Record<string, typeof producer.strains>
+  const strainsByDate = strains.reduce<
+    Record<string, typeof strains>
   >((acc, strain) => {
     if (strain.releaseDate) {
       const dateKey = strain.releaseDate.toISOString().split("T")[0];
@@ -187,8 +197,8 @@ export default async function DropsByProducerPage({
                   <div className="flex items-center gap-2">
                     <Calendar className="w-4 h-4 flex-shrink-0" />
                     <span className="text-sm sm:text-base">
-                      {producer.strains.length} drop
-                      {producer.strains.length !== 1 ? "s" : ""} this month
+                      {strains.length} drop
+                      {strains.length !== 1 ? "s" : ""} this month
                     </span>
                   </div>
                 </div>
@@ -228,8 +238,8 @@ export default async function DropsByProducerPage({
                   {currentYear}
                 </h2>
                 <div className="text-xs sm:text-sm text-green-100 bg-white/20 px-3 py-1 rounded-full">
-                  {producer.strains.length} strain
-                  {producer.strains.length !== 1 ? "s" : ""}
+                  {strains.length} strain
+                  {strains.length !== 1 ? "s" : ""}
                 </div>
               </div>
             </div>
@@ -350,13 +360,13 @@ export default async function DropsByProducerPage({
           </div>
 
           {/* Upcoming Drops List */}
-          {producer.strains.length > 0 && (
+          {strains.length > 0 && (
             <div>
               <h3 className="text-xl sm:text-2xl font-bold text-gray-900 mb-4 sm:mb-6">
                 Upcoming Releases
               </h3>
               <div className="grid gap-3 sm:gap-4">
-                {producer.strains.map((strain) => (
+                {strains.map((strain) => (
                   <StrainCard
                     key={strain.id}
                     strain={strain}
@@ -382,7 +392,7 @@ export default async function DropsByProducerPage({
           )}
 
           {/* Empty State - Enhanced */}
-          {producer.strains.length === 0 && (
+          {strains.length === 0 && (
             <div className="text-center py-12 sm:py-16">
               <div className="w-20 h-20 sm:w-24 sm:h-24 bg-gradient-to-br from-gray-100 to-gray-200 rounded-full flex items-center justify-center mx-auto mb-6 shadow-inner">
                 <Calendar className="w-10 h-10 sm:w-12 sm:h-12 text-gray-400" />

--- a/src/app/producer/[slug]/[strainSlug]/page.tsx
+++ b/src/app/producer/[slug]/[strainSlug]/page.tsx
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prismadb";
 import BackButton from "@/components/BackButton";
 import AddStrainReviewForm from "@/components/AddStrainReviewForm";
 import StrainReviewCard from "@/components/StrainReviewCard";
+import { Star } from "lucide-react";
 import { createSupabaseServerClient } from "@/lib/supabaseServer";
 
 interface StrainPageProps {
@@ -46,6 +47,10 @@ export default async function StrainPage({ params }: StrainPageProps) {
   }
 
   const reviews = strain.StrainReview;
+  const averageRating =
+    reviews.length > 0
+      ? reviews.reduce((sum, r) => sum + r.aggregateRating, 0) / reviews.length
+      : null;
   const userReview = currentUserId
     ? reviews.find((r) => r.userId === currentUserId) ?? null
     : null;
@@ -69,11 +74,21 @@ export default async function StrainPage({ params }: StrainPageProps) {
           <h1 className="text-3xl md:text-4xl font-bold text-gray-800">
             {strain.name}
           </h1>
-          {releaseDate && (
-            <p className="text-gray-600 mt-2">
-              Released on {releaseDate.toLocaleDateString()}
-            </p>
-          )}
+          <div className="flex flex-wrap items-center gap-4 mt-2">
+            {averageRating !== null && (
+              <div className="flex items-center text-yellow-500">
+                <Star className="w-5 h-5 mr-1" fill="currentColor" />
+                <span className="text-lg font-medium">
+                  {averageRating.toFixed(1)}
+                </span>
+              </div>
+            )}
+            {releaseDate && (
+              <p className="text-gray-600">
+                Released on {releaseDate.toLocaleDateString()}
+              </p>
+            )}
+          </div>
           <p className="text-sm text-gray-500 mt-1">
             by {" "}
             <Link

--- a/src/app/producer/[slug]/page.tsx
+++ b/src/app/producer/[slug]/page.tsx
@@ -58,6 +58,7 @@ export default async function ProducerProfilePage({
           releaseDate: true,
           strainSlug: true,
           _count: { select: { StrainReview: true } },
+          StrainReview: { select: { aggregateRating: true } },
         },
       },
     },
@@ -74,6 +75,15 @@ export default async function ProducerProfilePage({
   const totalScore = producer.votes.reduce((sum, vote) => sum + vote.value, 0);
   const averageRating =
     producer.votes.length > 0 ? totalScore / producer.votes.length : 0;
+
+  const strainsWithAvg = producer.strains.map(({ StrainReview, ...rest }) => {
+    const avg =
+      StrainReview.length > 0
+        ? StrainReview.reduce((sum, r) => sum + r.aggregateRating, 0) /
+          StrainReview.length
+        : null;
+    return { ...rest, avgRating: avg };
+  });
 
   const userVoteRecord = currentUserId
     ? await prisma.vote.findUnique({
@@ -249,7 +259,7 @@ export default async function ProducerProfilePage({
             <h3 className="text-xl font-semibold">Strains</h3>
           </div>
           <UpcomingStrainList
-            strains={producer.strains}
+            strains={strainsWithAvg}
             producerSlug={producer.slug ?? producer.id}
           />
         </div>

--- a/src/components/StrainCard.tsx
+++ b/src/components/StrainCard.tsx
@@ -3,7 +3,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { MessageCircle } from "lucide-react";
+import { MessageCircle, Star } from "lucide-react";
 import type { Strain } from "@prisma/client";
 import type { ReactNode } from "react";
 
@@ -11,7 +11,7 @@ interface StrainCardProps {
   strain: Pick<
     Strain,
     "id" | "name" | "imageUrl" | "strainSlug"
-  > & { _count?: { StrainReview: number } };
+  > & { _count?: { StrainReview: number }; avgRating?: number | null };
   producerSlug: string;
   children?: ReactNode;
 }
@@ -38,9 +38,17 @@ export default function StrainCard({
         <h3 className="text-lg font-semibold">{strain.name}</h3>
         {children}
       </div>
-      <div className="flex items-center text-sm text-gray-600">
-        <MessageCircle className="w-4 h-4 mr-1" />
-        {strain._count?.StrainReview ?? 0}
+      <div className="flex flex-col items-end text-sm text-gray-600">
+        {typeof strain.avgRating === "number" && (
+          <div className="flex items-center mb-1 text-yellow-500">
+            <Star className="w-4 h-4 mr-1" fill="currentColor" />
+            {strain.avgRating.toFixed(1)}
+          </div>
+        )}
+        <div className="flex items-center">
+          <MessageCircle className="w-4 h-4 mr-1" />
+          {strain._count?.StrainReview ?? 0}
+        </div>
       </div>
     </Link>
   );

--- a/src/components/UpcomingStrainList.tsx
+++ b/src/components/UpcomingStrainList.tsx
@@ -5,7 +5,7 @@ import StrainCard from "./StrainCard";
 type StrainListItem = Pick<
   Strain,
   "id" | "name" | "description" | "imageUrl" | "releaseDate" | "strainSlug"
-> & { _count?: { StrainReview: number } };
+> & { _count?: { StrainReview: number }; avgRating?: number | null };
 
 interface UpcomingStrainListProps {
   strains: StrainListItem[];


### PR DESCRIPTION
## Summary
- display average strain rating on strain cards
- compute and show strain-wide review average on strain pages

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68afe5279074832d9aa109272fa0cac7