### PR TITLE
Ensure drops pages fetch fresh strain data

### DIFF
--- a/src/app/drops/[producerSlug]/page.tsx
+++ b/src/app/drops/[producerSlug]/page.tsx
@@ -12,6 +12,9 @@ import {
 } from "lucide-react";
 import BackButton from "@/components/BackButton";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 interface DropsByProducerPageProps {
   params: Promise<{ producerSlug: string }>;
 }

--- a/src/app/drops/page.tsx
+++ b/src/app/drops/page.tsx
@@ -5,6 +5,9 @@ import StrainCard from "@/components/StrainCard";
 import { prisma } from "@/lib/prismadb";
 import { Calendar, TrendingUp, Clock, ChevronRight } from "lucide-react";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 export default async function DropsPage() {
   const now = new Date();
   const sevenDays = new Date();


### PR DESCRIPTION
## Summary
- disable caching on drops index and producer-specific pages
- force dynamic rendering so database queries run on every request

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(warning: If you set up ESLint yourself...)*

------
https://chatgpt.com/codex/tasks/task_e_68b08cc56e14832da3e2ed7a5dcac8e4