### PR TITLE
Redirect regular users to rankings after login

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -37,7 +37,7 @@ function LoginForm() {
         if (meData.role === "ADMIN") {
           router.push("/admin");
         } else {
-          router.push(`/profile/${meData.username || meData.id}`);
+          router.push("/rankings");
         }
       } else {
         router.push("/");


### PR DESCRIPTION
## Summary
- Redirect non-admin users to `/rankings` after login while keeping admin redirect to `/admin`.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: configuration prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8d6be8a98832dab38ab7d73464496