### PR TITLE
Sort and limit producer strains

### DIFF
--- a/src/app/drops/[producerSlug]/page.tsx
+++ b/src/app/drops/[producerSlug]/page.tsx
@@ -37,10 +37,11 @@ export default async function DropsByProducerPage({
   const month = parseInt(mstParts.find((p) => p.type === "month")!.value, 10);
   const day = parseInt(mstParts.find((p) => p.type === "day")!.value, 10);
 
-  const todayStart = new Date(Date.UTC(year, month - 1, day));
-  const oneMonthAgo = new Date(todayStart);
+  const todayUtc = Date.UTC(year, month - 1, day);
+  const todayStart = new Date(todayUtc);
+  const oneMonthAgo = new Date(todayUtc);
   oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
-  const oneMonthAhead = new Date(todayStart);
+  const oneMonthAhead = new Date(todayUtc);
   oneMonthAhead.setMonth(oneMonthAhead.getMonth() + 1);
 
   const producer = await prisma.producer.findFirst({
@@ -393,8 +394,12 @@ export default async function DropsByProducerPage({
                     ? new Date(strain.releaseDate)
                     : null;
                   const diffDays = releaseDate
-                    ? Math.ceil(
-                        (releaseDate.getTime() - now.getTime()) /
+                    ? Math.round(
+                        (Date.UTC(
+                          releaseDate.getUTCFullYear(),
+                          releaseDate.getUTCMonth(),
+                          releaseDate.getUTCDate()
+                        ) - todayUtc) /
                           (1000 * 60 * 60 * 24)
                       )
                     : null;

--- a/src/app/drops/page.tsx
+++ b/src/app/drops/page.tsx
@@ -23,8 +23,9 @@ export default async function DropsPage() {
   const month = parseInt(mstParts.find((p) => p.type === "month")!.value, 10);
   const day = parseInt(mstParts.find((p) => p.type === "day")!.value, 10);
 
-  const start = new Date(Date.UTC(year, month - 1, day - 7));
-  const end = new Date(Date.UTC(year, month - 1, day + 7));
+  const todayUtc = Date.UTC(year, month - 1, day);
+  const start = new Date(todayUtc - 7 * 24 * 60 * 60 * 1000);
+  const end = new Date(todayUtc + 7 * 24 * 60 * 60 * 1000);
 
   const strains = await prisma.strain.findMany({
     where: { releaseDate: { gte: start, lt: end } },
@@ -79,9 +80,12 @@ export default async function DropsPage() {
   );
 
   const getDaysUntilDrop = (releaseDate: Date) => {
-    const diffTime = releaseDate.getTime() - now.getTime();
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    return diffDays;
+    const releaseUtc = Date.UTC(
+      releaseDate.getUTCFullYear(),
+      releaseDate.getUTCMonth(),
+      releaseDate.getUTCDate()
+    );
+    return Math.round((releaseUtc - todayUtc) / (1000 * 60 * 60 * 24));
   };
 
   return (

--- a/src/app/drops/page.tsx
+++ b/src/app/drops/page.tsx
@@ -267,10 +267,10 @@ export default async function DropsPage() {
                     {strains.length > 3 && (
                       <div className="mt-4 sm:mt-6 text-center">
                         <Link
-                          href={`/drops/${producer.slug ?? producer.id}`}
+                          href={`/producer/${producer.slug ?? producer.id}/strains`}
                           className="group inline-flex items-center justify-center gap-2 text-green-600 hover:text-green-700 font-semibold text-sm sm:text-base bg-white hover:bg-gray-50 px-4 py-2 rounded-lg border border-green-200 hover:border-green-300 transition-all duration-200 shadow-sm hover:shadow"
                         >
-                          <span>View all {strains.length} strains</span>
+                          <span>See all {strains.length} strains</span>
                           <TrendingUp className="w-4 h-4 group-hover:translate-x-0.5 transition-transform" />
                         </Link>
                       </div>

--- a/src/app/producer/[slug]/page.tsx
+++ b/src/app/producer/[slug]/page.tsx
@@ -85,6 +85,18 @@ export default async function ProducerProfilePage({
     return { ...rest, avgRating: avg };
   });
 
+  strainsWithAvg.sort((a, b) => {
+    if (a.releaseDate && b.releaseDate) {
+      return b.releaseDate.getTime() - a.releaseDate.getTime();
+    }
+    if (a.releaseDate) return -1;
+    if (b.releaseDate) return 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  const totalStrains = strainsWithAvg.length;
+  const displayStrains = strainsWithAvg.slice(0, 5);
+
   const userVoteRecord = currentUserId
     ? await prisma.vote.findUnique({
         where: {
@@ -145,6 +157,7 @@ export default async function ProducerProfilePage({
     rank = producerIndex + 1;
   }
   const producerCategoryFormatted = capitalize(producer.category);
+  const producerSlug = producer.slug ?? producer.id;
 
   return (
     <div className="container mx-auto p-4">
@@ -256,18 +269,18 @@ export default async function ProducerProfilePage({
 
         <div className="mt-8">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-xl font-semibold">Strains</h3>
+            <h3 className="text-xl font-semibold">Strains ({totalStrains})</h3>
             <Link
-              href={`/drops/${producer.slug ?? producer.id}`}
+              href={`/producer/${producerSlug}/strains`}
               className="text-green-700 hover:text-green-800 hover:underline flex items-center"
             >
-              <span>See all drops</span>
+              <span>See all strains</span>
               <ArrowRight className="ml-1 h-4 w-4" />
             </Link>
           </div>
           <UpcomingStrainList
-            strains={strainsWithAvg}
-            producerSlug={producer.slug ?? producer.id}
+            strains={displayStrains}
+            producerSlug={producerSlug}
           />
         </div>
 

--- a/src/components/UpcomingStrainList.tsx
+++ b/src/components/UpcomingStrainList.tsx
@@ -21,6 +21,16 @@ export default function UpcomingStrainList({
   }
 
   const now = new Date();
+  const mstParts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/Denver",
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+  }).formatToParts(now);
+  const year = parseInt(mstParts.find((p) => p.type === "year")!.value, 10);
+  const month = parseInt(mstParts.find((p) => p.type === "month")!.value, 10);
+  const day = parseInt(mstParts.find((p) => p.type === "day")!.value, 10);
+  const todayUtc = Date.UTC(year, month - 1, day);
 
   const formatDate = (date: Date) =>
     new Intl.DateTimeFormat("en-US", {
@@ -34,10 +44,23 @@ export default function UpcomingStrainList({
           ? new Date(strain.releaseDate)
           : null;
         const diffDays = releaseDate
-          ? Math.ceil((releaseDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+          ? Math.round(
+              (Date.UTC(
+                releaseDate.getUTCFullYear(),
+                releaseDate.getUTCMonth(),
+                releaseDate.getUTCDate()
+              ) - todayUtc) /
+                (1000 * 60 * 60 * 24)
+            )
           : null;
         const showBadge = diffDays !== null && diffDays >= 0 && diffDays <= 30;
-        const hasDropped = releaseDate ? releaseDate < now : false;
+        const hasDropped = releaseDate
+          ? Date.UTC(
+              releaseDate.getUTCFullYear(),
+              releaseDate.getUTCMonth(),
+              releaseDate.getUTCDate()
+            ) < todayUtc
+          : false;
 
         return (
           <li key={strain.id}>


### PR DESCRIPTION
## Summary
- Sort producer strains by release date, then name, and show only top five
- Update producer profile to display total strain count and link to full strain list
- Link Drops page producer cards to new strains page

## Testing
- Skipped tests and linting as requested

------
https://chatgpt.com/codex/tasks/task_e_68b8ec312694832dad71fdbf571df957