### PR TITLE
feat: sort drops by upcoming date

### DIFF
--- a/src/app/drops/[producerSlug]/page.tsx
+++ b/src/app/drops/[producerSlug]/page.tsx
@@ -103,6 +103,23 @@ export default async function DropsByProducerPage({
     return { ...rest, avgRating: avg };
   });
 
+  const getDaysUntilDrop = (releaseDate: Date) => {
+    const releaseUtc = Date.UTC(
+      releaseDate.getUTCFullYear(),
+      releaseDate.getUTCMonth(),
+      releaseDate.getUTCDate()
+    );
+    return Math.round((releaseUtc - todayUtc) / (1000 * 60 * 60 * 24));
+  };
+
+  const upcomingStrains = strains
+    .filter(
+      (s) => s.releaseDate && getDaysUntilDrop(s.releaseDate) >= 0
+    )
+    .sort((a, b) =>
+      getDaysUntilDrop(a.releaseDate!) - getDaysUntilDrop(b.releaseDate!)
+    );
+
   const currentYear = year;
   const currentMonth = month - 1;
   const currentDay = day;
@@ -383,25 +400,18 @@ export default async function DropsByProducerPage({
           </div>
 
           {/* Upcoming Drops List */}
-          {strains.length > 0 && (
+          {upcomingStrains.length > 0 && (
             <div>
               <h3 className="text-xl sm:text-2xl font-bold text-gray-900 mb-4 sm:mb-6">
                 Upcoming Releases
               </h3>
               <div className="grid gap-3 sm:gap-4">
-                {strains.map((strain) => {
+                {upcomingStrains.map((strain) => {
                   const releaseDate = strain.releaseDate
                     ? new Date(strain.releaseDate)
                     : null;
                   const diffDays = releaseDate
-                    ? Math.round(
-                        (Date.UTC(
-                          releaseDate.getUTCFullYear(),
-                          releaseDate.getUTCMonth(),
-                          releaseDate.getUTCDate()
-                        ) - todayUtc) /
-                          (1000 * 60 * 60 * 24)
-                      )
+                    ? getDaysUntilDrop(releaseDate)
                     : null;
                   const showBadge =
                     diffDays !== null && diffDays >= 0 && diffDays <= 30;
@@ -446,7 +456,7 @@ export default async function DropsByProducerPage({
           )}
 
           {/* Empty State - Enhanced */}
-          {strains.length === 0 && (
+          {upcomingStrains.length === 0 && (
             <div className="text-center py-12 sm:py-16">
               <div className="w-20 h-20 sm:w-24 sm:h-24 bg-gradient-to-br from-gray-100 to-gray-200 rounded-full flex items-center justify-center mx-auto mb-6 shadow-inner">
                 <Calendar className="w-10 h-10 sm:w-12 sm:h-12 text-gray-400" />

--- a/src/app/drops/page.tsx
+++ b/src/app/drops/page.tsx
@@ -88,6 +88,37 @@ export default async function DropsPage() {
     return Math.round((releaseUtc - todayUtc) / (1000 * 60 * 60 * 24));
   };
 
+  const strainComparator = (
+    a: (typeof strainsWithAvg)[number],
+    b: (typeof strainsWithAvg)[number]
+  ) => {
+    if (!a.releaseDate || !b.releaseDate) return 0;
+    const daysA = getDaysUntilDrop(a.releaseDate);
+    const daysB = getDaysUntilDrop(b.releaseDate);
+    const aFuture = daysA >= 0;
+    const bFuture = daysB >= 0;
+    if (aFuture && !bFuture) return -1;
+    if (!aFuture && bFuture) return 1;
+    if (aFuture && bFuture) return daysA - daysB;
+    return daysB - daysA;
+  };
+
+  const producerGroups = Object.values(grouped)
+    .map((group) => ({
+      ...group,
+      strains: [...group.strains].sort(strainComparator),
+    }))
+    .sort((a, b) => {
+      const daysA = getDaysUntilDrop(a.strains[0].releaseDate!);
+      const daysB = getDaysUntilDrop(b.strains[0].releaseDate!);
+      const aFuture = daysA >= 0;
+      const bFuture = daysB >= 0;
+      if (aFuture && !bFuture) return -1;
+      if (!aFuture && bFuture) return 1;
+      if (aFuture && bFuture) return daysA - daysB;
+      return daysB - daysA;
+    });
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-emerald-50">
       {/* Hero Section */}
@@ -112,7 +143,7 @@ export default async function DropsPage() {
               </div>
               <div className="hidden sm:block w-px h-4 bg-green-300"></div>
               <div className="flex items-center gap-2">
-                <span className="text-sm font-medium">{Object.values(grouped).reduce((acc, group) => acc + group.strains.length, 0)} Strains</span>
+                <span className="text-sm font-medium">{producerGroups.reduce((acc, group) => acc + group.strains.length, 0)} Strains</span>
               </div>
             </div>
           </div>
@@ -120,7 +151,7 @@ export default async function DropsPage() {
       </div>
 
       <div className="px-4 sm:px-6 lg:px-8 py-8 sm:py-12 max-w-7xl mx-auto">
-        {Object.values(grouped).length === 0 ? (
+        {producerGroups.length === 0 ? (
           <div className="text-center py-12 sm:py-16">
             <div className="w-20 h-20 sm:w-24 sm:h-24 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4 sm:mb-6">
               <Calendar className="w-10 h-10 sm:w-12 sm:h-12 text-gray-400" />
@@ -132,7 +163,7 @@ export default async function DropsPage() {
           </div>
         ) : (
           <div className="space-y-6 sm:space-y-8">
-            {Object.values(grouped).map(({ producer, strains }) => (
+            {producerGroups.map(({ producer, strains }) => (
               <div key={producer.id} className="group">
                 {/* Producer Header Card */}
                 <div className="bg-white rounded-xl sm:rounded-2xl shadow-sm border border-gray-100 overflow-hidden hover:shadow-lg transition-all duration-300">


### PR DESCRIPTION
## Summary
- sort producer groups by nearest drop date on main page
- order strains by upcoming releases and show only upcoming on producer drops page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b9db38b418832d9069332fe4080798