### PR TITLE
Style weekly drop newsletter and toggle feedback

### DIFF
--- a/src/app/api/cron/send-weekly-drops/route.ts
+++ b/src/app/api/cron/send-weekly-drops/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prismadb";
 import { sendEmail } from "@/lib/email";
+import { weeklyDropsEmail } from "@/lib/emailTemplates";
 
 export async function GET() {
   const baseUrl = process.env.BASE_URL;
@@ -18,11 +19,10 @@ export async function GET() {
 
   for (const user of users) {
     try {
-      await sendEmail(
-        user.email,
-        "Upcoming Drops",
-        `${baseUrl}/drops`
-      );
+      const profileSlug = user.username || user.id;
+      const html = weeklyDropsEmail(baseUrl, profileSlug);
+      const text = `Check out this week's drops: ${baseUrl}/drops\n\nManage preferences: ${baseUrl}/profile/${profileSlug}`;
+      await sendEmail(user.email, "This Week's Drops", text, html);
     } catch (err) {
       console.error("sendEmail failed", err);
     }

--- a/src/components/NotificationOptInToggle.tsx
+++ b/src/components/NotificationOptInToggle.tsx
@@ -9,6 +9,7 @@ interface Props {
 export default function NotificationOptInToggle({ initial }: Props) {
   const [checked, setChecked] = useState(initial);
   const [isPending, startTransition] = useTransition();
+  const [toast, setToast] = useState<{ message: string; type: 'sub' | 'unsub' } | null>(null);
 
   const onChange = () => {
     const newValue = !checked;
@@ -20,6 +21,11 @@ export default function NotificationOptInToggle({ initial }: Props) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ notificationOptIn: newValue }),
         });
+        setToast({
+          message: newValue ? 'Subscribed' : 'Unsubscribed',
+          type: newValue ? 'sub' : 'unsub',
+        });
+        setTimeout(() => setToast(null), 3000);
       } catch (err) {
         console.error('Failed to update notification setting', err);
         setChecked(!newValue);
@@ -28,16 +34,27 @@ export default function NotificationOptInToggle({ initial }: Props) {
   };
 
   return (
-    <label className="inline-flex items-center space-x-2 cursor-pointer">
-      <input
-        type="checkbox"
-        className="form-checkbox h-5 w-5 text-green-600"
-        checked={checked}
-        onChange={onChange}
-        disabled={isPending}
-      />
-      <span>Receive weekly drop emails</span>
-    </label>
+    <>
+      {toast && (
+        <div
+          className={`fixed top-4 left-1/2 -translate-x-1/2 transform px-4 py-2 rounded-md text-white shadow-md z-50 ${
+            toast.type === 'sub' ? 'bg-green-600' : 'bg-red-600'
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
+      <label className="inline-flex items-center space-x-2 cursor-pointer">
+        <input
+          type="checkbox"
+          className="form-checkbox h-5 w-5 text-green-600"
+          checked={checked}
+          onChange={onChange}
+          disabled={isPending}
+        />
+        <span>Receive weekly drop emails</span>
+      </label>
+    </>
   );
 }
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,4 +1,9 @@
-export async function sendEmail(to: string, subject: string, text: string) {
+export async function sendEmail(
+  to: string,
+  subject: string,
+  text: string,
+  html?: string
+) {
   const apiKey = process.env.RESEND_API_KEY;
   const from = process.env.MAIL_FROM;
   if (!apiKey || !from) {
@@ -11,7 +16,7 @@ export async function sendEmail(to: string, subject: string, text: string) {
       Authorization: `Bearer ${apiKey}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ from, to, subject, text }),
+    body: JSON.stringify({ from, to, subject, text, ...(html ? { html } : {}) }),
   });
 
   if (!res.ok) {

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -1,0 +1,36 @@
+export function weeklyDropsEmail(baseUrl: string, profileSlug: string) {
+  const dropsUrl = `${baseUrl}/drops`;
+  const unsubscribeUrl = `${baseUrl}/profile/${profileSlug}`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Weekly Drops</title>
+    <style>
+      body { font-family: Arial, sans-serif; background-color: #f9fafb; margin: 0; padding: 0; }
+      .container { max-width: 600px; margin: 0 auto; background-color: #ffffff; padding: 24px; border-radius: 8px; }
+      h1 { color: #065f46; }
+      p { color: #374151; line-height: 1.5; }
+      .btn { display: inline-block; padding: 12px 24px; background-color: #059669; color: #ffffff; text-decoration: none; border-radius: 6px; margin-top: 16px; }
+      .unsubscribe { margin-top: 40px; font-size: 12px; color: #6b7280; }
+      .unsubscribe a { color: #6b7280; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>This Week's Drops</h1>
+      <p>Happy Sunday! Here's what's happening this week on Terptier.</p>
+      <p>New strains are dropping soon. Don't miss out!</p>
+      <p style="text-align:center;">
+        <a href="${dropsUrl}" class="btn">Check out this week's drops</a>
+      </p>
+      <p class="unsubscribe">
+        If you'd prefer not to receive these emails, you can <a href="${unsubscribeUrl}">unsubscribe here</a>.
+      </p>
+    </div>
+  </body>
+</html>`;
+}

--- a/supabase/edge-functions/send-email/index.ts
+++ b/supabase/edge-functions/send-email/index.ts
@@ -2,7 +2,7 @@ import { serve } from "https://deno.land/std@0.203.0/http/server.ts";
 
 serve(async (req) => {
   try {
-    const { to, subject, text } = await req.json();
+    const { to, subject, text, html } = await req.json();
     const apiKey = Deno.env.get("RESEND_API_KEY");
     const from = Deno.env.get("MAIL_FROM");
     if (!apiKey || !from) {
@@ -16,7 +16,7 @@ serve(async (req) => {
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ from, to, subject, text }),
+      body: JSON.stringify({ from, to, subject, text, ...(html ? { html } : {}) }),
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- Add HTML email template with newsletter styling and unsubscribe link
- Support HTML body in email sender and cron to send weekly drop newsletter
- Show toast on profile notification toggle for subscribe/unsubscribe feedback

## Testing
- ⚠️ `npm test` *(skipped: user requested)*
- ⚠️ `npm run lint` *(skipped: user requested)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b09328c4832d8c25ac6292f3635f