### PR TITLE
Fix Resend batch payload structure

### DIFF
--- a/src/app/api/cron/send-weekly-drops/route.ts
+++ b/src/app/api/cron/send-weekly-drops/route.ts
@@ -42,7 +42,7 @@ function createResendBatchClient(apiKey: string) {
   const endpoint = "https://api.resend.com/emails/batch";
 
   async function batchSend(
-    items: BatchEmailItem[],
+    emails: BatchEmailItem[],
     options: BatchSendOptions = {}
   ): Promise<BatchSendResult> {
     try {
@@ -55,14 +55,14 @@ function createResendBatchClient(apiKey: string) {
         headers["Idempotency-Key"] = options.idempotencyKey;
       }
 
-      const payload: Record<string, unknown> = {
-        emails: items,
-      };
-
       const validationSetting = options.batchValidation ?? "strict";
-      if (validationSetting) {
-        payload.batchValidation = validationSetting;
-      }
+      const payload = {
+        emails,
+        ...(validationSetting ? { batchValidation: validationSetting } : {}),
+      } satisfies {
+        emails: BatchEmailItem[];
+        batchValidation?: "permissive" | "strict";
+      };
 
       const res = await fetch(endpoint, {
         method: "POST",
@@ -196,7 +196,7 @@ export async function GET() {
 
   for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex += 1) {
     const chunkUsers = chunks[chunkIndex];
-    const items: BatchEmailItem[] = chunkUsers.map((user) => {
+    const emails: BatchEmailItem[] = chunkUsers.map((user) => {
       const profileSlug = user.username || user.id;
       const html = weeklyDropsEmail(baseUrl, profileSlug);
       const text = `Check out this week's drops: ${baseUrl}/drops\n\nManage preferences: ${baseUrl}/profile/${profileSlug}`;
@@ -214,7 +214,7 @@ export async function GET() {
 
     let attempt = 0;
     while (attempt < MAX_ATTEMPTS) {
-      const { data, error, errors } = await resend.batch.send(items, {
+      const { data, error, errors } = await resend.batch.send(emails, {
         batchValidation: "permissive",
         idempotencyKey,
       });


### PR DESCRIPTION
## Summary
- send batch email payloads using the `emails` array required by Resend
- keep permissive batch validation support while preserving idempotency headers

## Testing
- `npm run lint` *(fails: command is interactive without configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8f9e9730832da81b765aa3aa236f