### PR TITLE
Refactor app routes to be state-aware

### DIFF
--- a/src/app/[stateName]/drops/page.tsx
+++ b/src/app/[stateName]/drops/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Image from "next/image";
 import StrainCard from "@/components/StrainCard";
 import { prisma } from "@/lib/prismadb";
-import { Calendar, TrendingUp, ChevronRight } from "lucide-react";
+import { Calendar, ChevronRight, TrendingUp } from "lucide-react";
 import { unstable_noStore as noStore } from "next/cache";
 import { getStateMetadata } from "@/lib/states";
 import { notFound } from "next/navigation";
@@ -138,35 +138,6 @@ export default async function DropsPage({
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-emerald-50">
-      {/* Hero Section */}
-      <div className="relative overflow-hidden bg-gradient-to-r from-green-600 to-emerald-600 text-white">
-        <div className="absolute inset-0 bg-black/10"></div>
-        <div className="relative px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
-          <div className="max-w-4xl mx-auto text-center">
-            <div className="inline-flex items-center gap-2 bg-white/20 backdrop-blur-sm rounded-full px-3 sm:px-4 py-2 mb-4 sm:mb-6">
-              <TrendingUp className="w-4 h-4" />
-              <span className="text-sm font-medium">Weekly Drops</span>
-            </div>
-            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold mb-3 sm:mb-4 py-2 sm:py-4 bg-gradient-to-r from-white to-green-100 bg-clip-text text-transparent">
-              Recent & Upcoming Drops in {state.name}
-            </h1>
-            <p className="text-lg sm:text-xl text-green-100 mb-6 sm:mb-8 max-w-2xl mx-auto px-2">
-              Discover premium strains from the last week and the upcoming week from top-tier {state.name} producers
-            </p>
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 text-green-100">
-              <div className="flex items-center gap-2">
-                <Calendar className="w-5 h-5" />
-                <span className="text-sm font-medium">Last 7 & Next 7 Days</span>
-              </div>
-              <div className="hidden sm:block w-px h-4 bg-green-300"></div>
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium">{producerGroups.reduce((acc, group) => acc + group.strains.length, 0)} Strains</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
       <div className="px-4 sm:px-6 lg:px-8 py-8 sm:py-12 max-w-7xl mx-auto">
         {producerGroups.length === 0 ? (
           <div className="text-center py-12 sm:py-16">

--- a/src/app/[stateName]/drops/page.tsx
+++ b/src/app/[stateName]/drops/page.tsx
@@ -136,8 +136,45 @@ export default async function DropsPage({
       return daysB - daysA;
     });
 
+  const totalStrainCount = producerGroups.reduce(
+    (acc, group) => acc + group.strains.length,
+    0
+  );
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-emerald-50">
+      <div className="relative overflow-hidden bg-gradient-to-r from-green-600 to-emerald-600 text-white">
+        <div className="absolute inset-0 bg-black/10"></div>
+        <div className="relative px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
+          <div className="max-w-4xl mx-auto text-center">
+            <div className="inline-flex items-center gap-2 bg-white/20 backdrop-blur-sm rounded-full px-3 sm:px-4 py-2 mb-4 sm:mb-6">
+              <TrendingUp className="w-4 h-4" />
+              <span className="text-sm font-medium">Weekly Drops</span>
+            </div>
+            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold mb-3 sm:mb-4 py-2 sm:py-4 bg-gradient-to-r from-white to-green-100 bg-clip-text text-transparent">
+              {state.name} Recent & Upcoming Drops
+            </h1>
+            <p className="text-lg sm:text-xl text-green-100 mb-6 sm:mb-8 max-w-2xl mx-auto px-2">
+              Discover premium strains from the last week and the upcoming week from top-tier producers.
+            </p>
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 text-green-100">
+              <div className="flex items-center gap-2">
+                <Calendar className="w-5 h-5" />
+                <span className="text-sm font-medium">Last 7 & Next 7 Days</span>
+              </div>
+              <div className="hidden sm:block w-px h-4 bg-green-300"></div>
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">{producerGroups.length} Producer{producerGroups.length === 1 ? "" : "s"}</span>
+              </div>
+              <div className="hidden sm:block w-px h-4 bg-green-300"></div>
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">{totalStrainCount} Strain{totalStrainCount === 1 ? "" : "s"}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div className="px-4 sm:px-6 lg:px-8 py-8 sm:py-12 max-w-7xl mx-auto">
         {producerGroups.length === 0 ? (
           <div className="text-center py-12 sm:py-16">

--- a/src/app/[stateName]/layout.tsx
+++ b/src/app/[stateName]/layout.tsx
@@ -5,7 +5,6 @@ import {
   generateStateStaticParams,
 } from "@/lib/states";
 import { StateProvider } from "@/components/StateProvider";
-import StateNavLinks from "@/components/StateNavLinks";
 
 export function generateStaticParams() {
   return generateStateStaticParams();
@@ -25,36 +24,9 @@ export default async function StateLayout({
     notFound();
   }
 
-  const navLinks = [
-    { label: "Rankings", href: `/${state.slug}/rankings` },
-    { label: "Drops", href: `/${state.slug}/drops` },
-  ];
-
   return (
     <StateProvider stateSlug={state.slug}>
-      <div className="flex flex-col gap-6">
-        <div className="bg-white border border-gray-100 rounded-2xl shadow-sm">
-          <div className="px-6 py-6 md:px-10 md:py-8 flex flex-col gap-6">
-            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <div>
-                <p className="text-sm uppercase tracking-wide text-green-600">
-                  TerpTier States
-                </p>
-                <h1 className="text-3xl font-bold text-gray-900">
-                  {state.name}
-                </h1>
-                {state.tagline ? (
-                  <p className="mt-2 text-sm text-gray-600 max-w-xl">
-                    {state.tagline}
-                  </p>
-                ) : null}
-              </div>
-            </div>
-            <StateNavLinks links={navLinks} />
-          </div>
-        </div>
-        <div>{children}</div>
-      </div>
+      {children}
     </StateProvider>
   );
 }

--- a/src/app/[stateName]/layout.tsx
+++ b/src/app/[stateName]/layout.tsx
@@ -1,9 +1,7 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { ReactNode } from "react";
 import {
   getStateMetadata,
-  STATES,
   generateStateStaticParams,
 } from "@/lib/states";
 import { StateProvider } from "@/components/StateProvider";
@@ -50,21 +48,6 @@ export default async function StateLayout({
                     {state.tagline}
                   </p>
                 ) : null}
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {STATES.map((s) => (
-                  <Link
-                    key={s.slug}
-                    href={`/${s.slug}/rankings`}
-                    className={`rounded-full border px-4 py-1.5 text-sm font-medium transition-colors ${
-                      s.slug === state.slug
-                        ? "bg-green-600 text-white border-green-600"
-                        : "bg-white text-gray-700 hover:bg-gray-50"
-                    }`}
-                  >
-                    {s.abbreviation}
-                  </Link>
-                ))}
               </div>
             </div>
             <StateNavLinks links={navLinks} />

--- a/src/app/[stateName]/layout.tsx
+++ b/src/app/[stateName]/layout.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { ReactNode } from "react";
+import {
+  getStateMetadata,
+  STATES,
+  generateStateStaticParams,
+} from "@/lib/states";
+import { StateProvider } from "@/components/StateProvider";
+import StateNavLinks from "@/components/StateNavLinks";
+
+export function generateStaticParams() {
+  return generateStateStaticParams();
+}
+
+export default async function StateLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ stateName: string }>;
+}) {
+  const { stateName } = await params;
+  const state = getStateMetadata(stateName);
+
+  if (!state) {
+    notFound();
+  }
+
+  const navLinks = [
+    { label: "Rankings", href: `/${state.slug}/rankings` },
+    { label: "Drops", href: `/${state.slug}/drops` },
+  ];
+
+  return (
+    <StateProvider stateSlug={state.slug}>
+      <div className="flex flex-col gap-6">
+        <div className="bg-white border border-gray-100 rounded-2xl shadow-sm">
+          <div className="px-6 py-6 md:px-10 md:py-8 flex flex-col gap-6">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-sm uppercase tracking-wide text-green-600">
+                  TerpTier States
+                </p>
+                <h1 className="text-3xl font-bold text-gray-900">
+                  {state.name}
+                </h1>
+                {state.tagline ? (
+                  <p className="mt-2 text-sm text-gray-600 max-w-xl">
+                    {state.tagline}
+                  </p>
+                ) : null}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {STATES.map((s) => (
+                  <Link
+                    key={s.slug}
+                    href={`/${s.slug}/rankings`}
+                    className={`rounded-full border px-4 py-1.5 text-sm font-medium transition-colors ${
+                      s.slug === state.slug
+                        ? "bg-green-600 text-white border-green-600"
+                        : "bg-white text-gray-700 hover:bg-gray-50"
+                    }`}
+                  >
+                    {s.abbreviation}
+                  </Link>
+                ))}
+              </div>
+            </div>
+            <StateNavLinks links={navLinks} />
+          </div>
+        </div>
+        <div>{children}</div>
+      </div>
+    </StateProvider>
+  );
+}

--- a/src/app/[stateName]/rankings/page.tsx
+++ b/src/app/[stateName]/rankings/page.tsx
@@ -8,6 +8,13 @@ import { prisma } from "@/lib/prismadb";
 import { Category } from "@prisma/client";
 import { getStateMetadata } from "@/lib/states";
 import { notFound } from "next/navigation";
+import {
+  Crown,
+  Users,
+  Star,
+  Flower2,
+  FlaskConical,
+} from "lucide-react";
 
 export default async function RankingsPage({
   params,
@@ -85,9 +92,64 @@ export default async function RankingsPage({
   const { view } = await searchParams;
   const initialViewParam = view === "hash" ? "hash" : "flower";
 
+  const totalProducers = flower.length + hash.length;
+  const totalVotes =
+    [...flower, ...hash].reduce((acc, p) => acc + p.votes.length, 0) || 0;
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-emerald-50 py-10 md:py-12">
-      <div className="container mx-auto px-2 md:px-4">
+    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-emerald-50">
+      <div className="relative overflow-hidden bg-gradient-to-r from-green-600 to-emerald-600 text-white">
+        <div className="absolute inset-0 bg-black/10"></div>
+        <div className="relative container mx-auto px-4 py-16">
+          <div className="max-w-4xl mx-auto text-center">
+            <div className="inline-flex items-center gap-2 bg-white/20 backdrop-blur-sm rounded-full px-4 py-2 mb-6">
+              <Crown className="w-4 h-4" />
+              <span className="text-sm font-medium">Community Rankings</span>
+            </div>
+
+            <h1 className="text-5xl md:text-6xl font-bold mb-4 py-4 bg-gradient-to-r from-white to-green-100 bg-clip-text text-transparent">
+              {state.name} Producer Rankings
+            </h1>
+
+            <p className="text-lg md:text-xl text-green-100 mb-8 max-w-2xl mx-auto">
+              {state.tagline ??
+                "Vote for your favorite producers and see who\'s in the lead! Scores are community-driven and update as votes roll in."}
+            </p>
+
+            <div className="flex flex-wrap items-center justify-center gap-6 text-green-100">
+              <div className="flex items-center gap-2">
+                <Users className="w-5 h-5" />
+                <span className="text-sm font-medium">
+                  {totalProducers} Producer{totalProducers === 1 ? "" : "s"}
+                </span>
+              </div>
+              <div className="w-px h-4 bg-green-300"></div>
+              <div className="flex items-center gap-2">
+                <Star className="w-5 h-5" />
+                <span className="text-sm font-medium">
+                  {totalVotes} Vote{totalVotes === 1 ? "" : "s"}
+                </span>
+              </div>
+              <div className="w-px h-4 bg-green-300"></div>
+              <div className="flex items-center gap-2">
+                <Flower2 className="w-5 h-5" />
+                <span className="text-sm font-medium">
+                  {flower.length} Grower{flower.length === 1 ? "" : "s"}
+                </span>
+              </div>
+              <div className="w-px h-4 bg-green-300"></div>
+              <div className="flex items-center gap-2">
+                <FlaskConical className="w-5 h-5" />
+                <span className="text-sm font-medium">
+                  {hash.length} Hasher{hash.length === 1 ? "" : "s"}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="container mx-auto px-2 md:px-4 py-10 md:py-12">
         <ProducerList
           initialData={{ flower, hash }}
           userVotes={userVotes}

--- a/src/app/[stateName]/rankings/page.tsx
+++ b/src/app/[stateName]/rankings/page.tsx
@@ -8,14 +8,6 @@ import { prisma } from "@/lib/prismadb";
 import { Category } from "@prisma/client";
 import { getStateMetadata } from "@/lib/states";
 import { notFound } from "next/navigation";
-import {
-  Crown,
-  TrendingUp,
-  Users,
-  Star,
-  Flower2,
-  FlaskConical,
-} from "lucide-react";
 
 export default async function RankingsPage({
   params,
@@ -93,73 +85,14 @@ export default async function RankingsPage({
   const { view } = await searchParams;
   const initialViewParam = view === "hash" ? "hash" : "flower";
 
-  // Hero metrics
-  const totalProducers = flower.length + hash.length;
-  const totalVotes =
-    [...flower, ...hash].reduce((acc, p) => acc + p.votes.length, 0) || 0;
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-emerald-50">
-      {/* Hero Section — modeled after /drops */}
-      <div className="relative overflow-hidden bg-gradient-to-r from-green-600 to-emerald-600 text-white">
-        <div className="absolute inset-0 bg-black/10"></div>
-        <div className="relative container mx-auto px-4 py-16">
-          <div className="max-w-4xl mx-auto text-center">
-            <div className="inline-flex items-center gap-2 bg-white/20 backdrop-blur-sm rounded-full px-4 py-2 mb-6">
-              <Crown className="w-4 h-4" />
-              <span className="text-sm font-medium">Community Rankings</span>
-            </div>
-
-            <h1 className="text-5xl md:text-6xl font-bold mb-4 py-4 bg-gradient-to-r from-white to-green-100 bg-clip-text text-transparent">
-              {state.name} Producer Rankings
-            </h1>
-
-            <p className="text-lg md:text-xl text-green-100 mb-8 max-w-2xl mx-auto">
-              Vote for your favorite producers and see who&apos;s in the lead! Scores are
-              community-driven and update as votes roll in.
-            </p>
-
-            {/* Quick metrics */}
-            <div className="flex flex-wrap items-center justify-center gap-6 text-green-100">
-              <div className="flex items-center gap-2">
-                <Users className="w-5 h-5" />
-                <span className="text-sm font-medium">
-                  {totalProducers} Producers
-                </span>
-              </div>
-              <div className="w-px h-4 bg-green-300"></div>
-              <div className="flex items-center gap-2">
-                <Star className="w-5 h-5" />
-                <span className="text-sm font-medium">
-                  {totalVotes} Vote{totalVotes === 1 ? "" : "s"}
-                </span>
-              </div>
-              <div className="w-px h-4 bg-green-300"></div>
-              <div className="flex items-center gap-2">
-                <Flower2 className="w-5 h-5" />
-                <span className="text-sm font-medium">
-                  {flower.length} Growers
-                </span>
-              </div>
-              <div className="w-px h-4 bg-green-300"></div>
-              <div className="flex items-center gap-2">
-                <FlaskConical className="w-5 h-5" />
-                <span className="text-sm font-medium">{hash.length} Hashers</span>
-              </div>
-            </div>
-
-            {/* View toggles (links keep SSR simple and reflect state in URL) */}
-          </div>
-        </div>
-      </div>
-
-      {/* Content */}
-      <div className="container mx-auto px-2 md:px-4 py-10 md:py-12">
-          <ProducerList
-            initialData={{ flower, hash }}
-            userVotes={userVotes}
-            initialView={initialViewParam}
-          />
+    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-emerald-50 py-10 md:py-12">
+      <div className="container mx-auto px-2 md:px-4">
+        <ProducerList
+          initialData={{ flower, hash }}
+          userVotes={userVotes}
+          initialView={initialViewParam}
+        />
 
         <div className="text-center mt-8">
           <Link

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
+import { DEFAULT_STATE_SLUG } from "@/lib/states";
 
 export default function AboutPage() {
   return (
@@ -322,13 +323,13 @@ export default function AboutPage() {
 
             {/* Navigation Buttons */}
             <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center mb-6 sm:mb-8">
-              <Link href="/rankings" className="w-full sm:w-auto">
+              <Link href={`/${DEFAULT_STATE_SLUG}/rankings`} className="w-full sm:w-auto">
                 <button className="group w-full sm:w-auto inline-flex cursor-pointer items-center justify-center px-6 sm:px-8 py-3 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 transition-all duration-200 shadow-lg hover:shadow-xl transform hover:scale-105">
                   <span>Explore Brands</span>
                   <ChevronRight className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform" />
                 </button>
               </Link>
-              <Link href="/drops" className="w-full sm:w-auto">
+              <Link href={`/${DEFAULT_STATE_SLUG}/drops`} className="w-full sm:w-auto">
                 <button className="group w-full sm:w-auto inline-flex cursor-pointer items-center justify-center px-6 sm:px-8 py-3 bg-purple-600 text-white font-semibold rounded-lg hover:bg-purple-700 transition-all duration-200 shadow-lg hover:shadow-xl transform hover:scale-105">
                   <Calendar className="w-5 h-5 mr-2" />
                   <span>Upcoming Drops</span>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
+import { DEFAULT_STATE_SLUG } from "@/lib/states";
 
 function LoginForm() {
   const router = useRouter();
@@ -37,7 +38,7 @@ function LoginForm() {
         if (meData.role === "ADMIN") {
           router.push("/admin");
         } else {
-          router.push("/rankings");
+          router.push(`/${DEFAULT_STATE_SLUG}/rankings`);
         }
       } else {
         router.push("/");

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -11,6 +11,9 @@ import { prisma } from "@/lib/prismadb";
 import { cookies } from "next/headers";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { Instagram, ExternalLink, Link as LinkIcon } from "lucide-react";
+import ProducerCard from "@/components/ProducerCard";
+import { getStateFromAttributes } from "@/lib/states";
+import { StateProvider } from "@/components/StateProvider";
 
 export const dynamic = "force-dynamic";
 
@@ -267,18 +270,20 @@ export default async function ProfilePage({
                 const j = rank % 10;
                 const k = rank % 100;
                 const suffix = j === 1 && k !== 11 ? "st" : j === 2 && k !== 12 ? "nd" : j === 3 && k !== 13 ? "rd" : "th";
+                const producerState = getStateFromAttributes(producer.attributes);
 
                 return (
-                  <ProducerCard
-                    key={producer.id}
-                    rank={rank}
-                    rankSuffix={suffix}
-                    producer={producer}
-                    userVoteValue={producer.userActualVote}
-                    color="none"
-                    useColors={false}
-                    showRank={false}
-                  />
+                  <StateProvider key={producer.id} stateSlug={producerState.slug}>
+                    <ProducerCard
+                      rank={rank}
+                      rankSuffix={suffix}
+                      producer={producer}
+                      userVoteValue={producer.userActualVote}
+                      color="none"
+                      useColors={false}
+                      showRank={false}
+                    />
+                  </StateProvider>
                 );
               })}
             </div>
@@ -286,20 +291,31 @@ export default async function ProfilePage({
 
           {/* Strain Reviews Section */}
           <ExpandableSection title="Strain Reviews" count={user.StrainReview.length} initialShowCount={4}>
-            {user.StrainReview.map((review) => (
-              <div key={review.id} className="bg-gradient-to-r from-green-50 to-emerald-50 rounded-xl p-4 border border-green-100">
-                <Link
-                  href={`/producer/${review.strain.producer.slug}/${review.strain.strainSlug}`}
-                  className="inline-block text-xl font-semibold text-green-700 hover:text-green-800 transition-colors mb-3 hover:underline"
+            {user.StrainReview.map((review) => {
+              const producerState = getStateFromAttributes(
+                review.strain.producer.attributes
+              );
+              const producerSlug =
+                review.strain.producer.slug ?? review.strain.producer.id;
+
+              return (
+                <div
+                  key={review.id}
+                  className="bg-gradient-to-r from-green-50 to-emerald-50 rounded-xl p-4 border border-green-100"
                 >
-                  {review.strain.name}
-                </Link>
+                  <Link
+                    href={`/${producerState.slug}/producer/${producerSlug}/${review.strain.strainSlug}`}
+                    className="inline-block text-xl font-semibold text-green-700 hover:text-green-800 transition-colors mb-3 hover:underline"
+                  >
+                    {review.strain.name}
+                  </Link>
                 <StrainReviewCard
                   review={review}
                   currentUserId={currentViewerId}
                 />
-              </div>
-            ))}
+                </div>
+              );
+            })}
           </ExpandableSection>
         </div>
       </div>

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -7,6 +7,7 @@ import { Leaf, Trash2, FilePenLine } from "lucide-react";
 import VoteButton from "@/components/VoteButton";
 import UploadButton from "./UploadButton";
 import { deleteBlob } from "@/utils/blob";
+import { useStateSlug } from "./StateProvider";
 
 export interface CommentData {
   id: string;
@@ -43,6 +44,7 @@ export default function CommentCard({
   const [expandedImage, setExpandedImage] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   const router = useRouter();
+  const stateSlug = useStateSlug();
 
   const MAX_SIZE = 5 * 1024 * 1024;
 
@@ -171,7 +173,13 @@ export default function CommentCard({
       </div>
       {comment.producer && (
         <p className="text-sm text-gray-700 mb-1">
-          For producer: <a href={`/producer/${comment.producer.slug ?? comment.producer.id}`} className="underline hover:text-blue-600">{comment.producer.name}</a>
+          For producer:
+          <Link
+            href={`/${stateSlug}/producer/${comment.producer.slug ?? comment.producer.id}`}
+            className="ml-1 underline hover:text-blue-600"
+          >
+            {comment.producer.name}
+          </Link>
         </p>
       )}
       {showRating && (

--- a/src/components/HeroHome.tsx
+++ b/src/components/HeroHome.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from "react";
 import { motion, useAnimation, useScroll, useTransform } from "framer-motion";
 import { ChevronRight, Star, Users, TrendingUp, Cannabis } from "lucide-react";
 import Link from "next/link";
+import { DEFAULT_STATE_SLUG } from "@/lib/states";
 import Image from "next/image";
 
 export default function HeroHome() {
@@ -175,7 +176,7 @@ export default function HeroHome() {
           variants={itemVariants}
           className="flex flex-col sm:flex-row gap-4 mb-12"
         >
-          <Link href="/rankings">
+          <Link href={`/${DEFAULT_STATE_SLUG}/rankings`}>
             <motion.button
               whileHover={{
                 scale: 1.05,
@@ -194,7 +195,7 @@ export default function HeroHome() {
               </div>
             </motion.button>
           </Link>
-          <Link href="/drops">
+          <Link href={`/${DEFAULT_STATE_SLUG}/drops`}>
             <motion.button
               whileHover={{
                 scale: 1.05,

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,9 +10,12 @@ import Image from "next/image";
 import { LogIn, LogOut } from "lucide-react";
 import type { Session } from "@supabase/supabase-js";
 import DropOptInModal from "./DropOptInModal";
+import { DEFAULT_STATE_SLUG } from "@/lib/states";
 
 export default function Navbar() {
   const pathname = usePathname();
+  const defaultDropsPath = `/${DEFAULT_STATE_SLUG}/drops`;
+  const defaultRankingsPath = `/${DEFAULT_STATE_SLUG}/rankings`;
   const [session, setSession] = useState<Session | null>(null);
   const [profileUsername, setProfileUsername] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
@@ -161,17 +164,21 @@ export default function Navbar() {
           <div className="absolute right-8 top-1/2 -translate-y-1/2 md:hidden"></div>
           <div className="hidden md:flex items-center space-x-6">
             <Link
-              href="/drops"
+              href={defaultDropsPath}
               className={`${
-                pathname === "/drops" ? "underline" : "hover:underline"
+                pathname?.includes("/drops")
+                  ? "underline"
+                  : "hover:underline"
               }`}
             >
               Drops
             </Link>
             <Link
-              href="/rankings"
+              href={defaultRankingsPath}
               className={`${
-                pathname === "/rankings" ? "underline" : "hover:underline"
+                pathname?.includes("/rankings")
+                  ? "underline"
+                  : "hover:underline"
               }`}
             >
               Rankings
@@ -236,14 +243,14 @@ export default function Navbar() {
               className="md:hidden overflow-hidden bg-green-800 border-t border-b border-green-900 pt-4 pb-6 space-y-4 flex flex-col items-center text-white"
             >
               <Link
-                href="/drops"
+                href={defaultDropsPath}
                 onClick={() => setMenuOpen(false)}
                 className="w-full text-center py-1"
               >
                 Drops
               </Link>
               <Link
-                href="/rankings"
+                href={defaultRankingsPath}
                 onClick={() => setMenuOpen(false)}
                 className="w-full text-center py-1"
               >

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,21 +1,38 @@
 // src/components/Navbar.tsx
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
 import Image from "next/image";
 import { LogIn, LogOut } from "lucide-react";
 import type { Session } from "@supabase/supabase-js";
 import DropOptInModal from "./DropOptInModal";
-import { DEFAULT_STATE_SLUG } from "@/lib/states";
+import { DEFAULT_STATE_SLUG, STATES } from "@/lib/states";
+
+const STATE_STORAGE_KEY = "terptier:selectedState";
+
+const stateSlugSet = new Set(STATES.map((state) => state.slug));
+
+const getStateSlugFromPath = (pathname: string | null): string | null => {
+  if (!pathname) {
+    return null;
+  }
+
+  const match = pathname.match(/^\/([^/]+)(?:\/|$)/);
+  if (!match) {
+    return null;
+  }
+
+  const slug = match[1];
+  return stateSlugSet.has(slug) ? slug : null;
+};
 
 export default function Navbar() {
   const pathname = usePathname();
-  const defaultDropsPath = `/${DEFAULT_STATE_SLUG}/drops`;
-  const defaultRankingsPath = `/${DEFAULT_STATE_SLUG}/rankings`;
+  const router = useRouter();
   const [session, setSession] = useState<Session | null>(null);
   const [profileUsername, setProfileUsername] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
@@ -23,7 +40,58 @@ export default function Navbar() {
   const [showBar, setShowBar] = useState(true);
   const [notificationOptIn, setNotificationOptIn] = useState(true);
   const [showDropModal, setShowDropModal] = useState(false);
+  const [selectedState, setSelectedState] = useState(DEFAULT_STATE_SLUG);
   const lastScrollY = useRef(0);
+
+  const dropsPath = useMemo(
+    () => `/${selectedState}/drops`,
+    [selectedState],
+  );
+  const rankingsPath = useMemo(
+    () => `/${selectedState}/rankings`,
+    [selectedState],
+  );
+
+  const handleStateChange = (newState: string) => {
+    setSelectedState(newState);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STATE_STORAGE_KEY, newState);
+    }
+
+    const activeSlug = getStateSlugFromPath(pathname);
+    if (activeSlug) {
+      const remainder = pathname?.slice(activeSlug.length + 1) ?? "";
+      const normalizedRemainder = remainder
+        ? remainder.startsWith("/")
+          ? remainder
+          : `/${remainder}`
+        : "/rankings";
+      const nextPath = `/${newState}${normalizedRemainder}`;
+      router.push(nextPath);
+    } else {
+      router.push(`/${newState}/rankings`);
+    }
+  };
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const slugFromPath = getStateSlugFromPath(pathname);
+    if (slugFromPath) {
+      setSelectedState(slugFromPath);
+      window.localStorage.setItem(STATE_STORAGE_KEY, slugFromPath);
+      return;
+    }
+
+    const stored = window.localStorage.getItem(STATE_STORAGE_KEY);
+    if (stored && stateSlugSet.has(stored)) {
+      setSelectedState(stored);
+    } else {
+      setSelectedState(DEFAULT_STATE_SLUG);
+    }
+  }, [pathname]);
 
   useEffect(() => {
     // fetch initial session
@@ -163,10 +231,27 @@ export default function Navbar() {
           </div>
           <div className="absolute right-8 top-1/2 -translate-y-1/2 md:hidden"></div>
           <div className="hidden md:flex items-center space-x-6">
+            <div className="flex items-center space-x-2">
+              <label htmlFor="state-select" className="text-sm text-green-100">
+                State
+              </label>
+              <select
+                id="state-select"
+                className="bg-white text-green-700 text-sm rounded-full px-3 py-1 focus:outline-none focus:ring-2 focus:ring-green-300"
+                value={selectedState}
+                onChange={(event) => handleStateChange(event.target.value)}
+              >
+                {STATES.map((state) => (
+                  <option key={state.slug} value={state.slug}>
+                    {state.name}
+                  </option>
+                ))}
+              </select>
+            </div>
             <Link
-              href={defaultDropsPath}
+              href={dropsPath}
               className={`${
-                pathname?.includes("/drops")
+                pathname?.startsWith(dropsPath)
                   ? "underline"
                   : "hover:underline"
               }`}
@@ -174,9 +259,9 @@ export default function Navbar() {
               Drops
             </Link>
             <Link
-              href={defaultRankingsPath}
+              href={rankingsPath}
               className={`${
-                pathname?.includes("/rankings")
+                pathname?.startsWith(rankingsPath)
                   ? "underline"
                   : "hover:underline"
               }`}
@@ -242,15 +327,35 @@ export default function Navbar() {
               transition={{ duration: 0.45, ease: "easeInOut" }}
               className="md:hidden overflow-hidden bg-green-800 border-t border-b border-green-900 pt-4 pb-6 space-y-4 flex flex-col items-center text-white"
             >
+              <div className="w-full px-6">
+                <label htmlFor="mobile-state-select" className="block text-xs uppercase tracking-wide text-green-200 mb-1">
+                  State
+                </label>
+                <select
+                  id="mobile-state-select"
+                  className="w-full bg-white text-green-700 text-sm rounded-full px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-300"
+                  value={selectedState}
+                  onChange={(event) => {
+                    handleStateChange(event.target.value);
+                    setMenuOpen(false);
+                  }}
+                >
+                  {STATES.map((state) => (
+                    <option key={state.slug} value={state.slug}>
+                      {state.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
               <Link
-                href={defaultDropsPath}
+                href={dropsPath}
                 onClick={() => setMenuOpen(false)}
                 className="w-full text-center py-1"
               >
                 Drops
               </Link>
               <Link
-                href={defaultRankingsPath}
+                href={rankingsPath}
                 onClick={() => setMenuOpen(false)}
                 className="w-full text-center py-1"
               >

--- a/src/components/ProducerCard.tsx
+++ b/src/components/ProducerCard.tsx
@@ -7,6 +7,7 @@ import { MessageCircle } from "lucide-react";
 import type { ProducerWithVotes } from "./ProducerList";
 import { ATTRIBUTE_OPTIONS } from "@/constants/attributes";
 import Tooltip from "./Tooltip";
+import { useStateSlug } from "./StateProvider";
 
 export default function ProducerCard({
   rank,
@@ -27,6 +28,7 @@ export default function ProducerCard({
   showRank?: boolean;
   useColors?: boolean;
 }) {
+  const stateSlug = useStateSlug();
   const total = producer.votes.reduce((sum, v) => sum + v.value, 0);
   const average = producer.votes.length ? total / producer.votes.length : 0;
   const userVote = userVoteValue;
@@ -49,7 +51,7 @@ export default function ProducerCard({
       ? "glow-bronze"
       : "";
 
-  const link = `/producer/${producer.slug ?? producer.id}`;
+  const link = `/${stateSlug}/producer/${producer.slug ?? producer.id}`;
 
   const badgeClasses = `flex items-center justify-center ${colorClasses[useColors ? color : "none"]} rounded-full w-10 h-10 font-bold`;
 

--- a/src/components/StateNavLinks.tsx
+++ b/src/components/StateNavLinks.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface NavLink {
+  label: string;
+  href: string;
+}
+
+export default function StateNavLinks({ links }: { links: NavLink[] }) {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex flex-wrap gap-3 text-sm font-medium">
+      {links.map((link) => {
+        const isActive = pathname.startsWith(link.href);
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={`rounded-full px-4 py-2 transition-colors ${
+              isActive
+                ? "bg-green-600 text-white shadow"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+            }`}
+          >
+            {link.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/StateProvider.tsx
+++ b/src/components/StateProvider.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import { DEFAULT_STATE_SLUG } from "@/lib/states";
+
+const StateSlugContext = createContext<string>(DEFAULT_STATE_SLUG);
+
+export function StateProvider({
+  stateSlug,
+  children,
+}: {
+  stateSlug: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <StateSlugContext.Provider value={stateSlug}>
+      {children}
+    </StateSlugContext.Provider>
+  );
+}
+
+export function useStateSlug() {
+  return useContext(StateSlugContext);
+}

--- a/src/components/StrainCard.tsx
+++ b/src/components/StrainCard.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { MessageCircle, Star } from "lucide-react";
 import type { Strain } from "@prisma/client";
 import type { ReactNode } from "react";
+import { useStateSlug } from "./StateProvider";
 
 interface StrainCardProps {
   strain: Pick<
@@ -21,9 +22,10 @@ export default function StrainCard({
   producerSlug,
   children,
 }: StrainCardProps) {
+  const stateSlug = useStateSlug();
   return (
     <Link
-      href={`/producer/${producerSlug}/${strain.strainSlug}`}
+      href={`/${stateSlug}/producer/${producerSlug}/${strain.strainSlug}`}
       className="flex items-center space-x-4 bg-white shadow rounded p-4 hover:bg-gray-50 transition"
     >
       <div className="relative w-16 h-16 flex-shrink-0">

--- a/src/components/VoteButton.tsx
+++ b/src/components/VoteButton.tsx
@@ -5,6 +5,7 @@ import { Star } from "lucide-react";
 import { supabase } from "@/lib/supabaseClient";
 import type { Session } from "@supabase/supabase-js";
 import { useRouter } from "next/navigation";
+import { useStateSlug } from "./StateProvider";
 
 export default function VoteButton({
   producerId,
@@ -26,6 +27,7 @@ export default function VoteButton({
   compact?: boolean;
 }) {
   const router = useRouter();
+  const stateSlug = useStateSlug();
   const [session, setSession] = useState<Session | null>(null);
   const [rating, setRating] = useState(userRating ?? 0);
   const [showTooltip, setShowTooltip] = useState(false);
@@ -46,7 +48,7 @@ export default function VoteButton({
   const cast = async (val: number) => {
     if (readOnly) {
       if (navigateOnClick) {
-        router.push(`/producer/${linkSlug ?? producerId}`);
+        router.push(`/${stateSlug}/producer/${linkSlug ?? producerId}`);
       }
       return;
     }

--- a/src/lib/states.ts
+++ b/src/lib/states.ts
@@ -1,0 +1,65 @@
+import { Prisma } from "@prisma/client";
+
+export type StateMetadata = {
+  slug: string;
+  name: string;
+  abbreviation: string;
+  tagline?: string;
+  producerWhere?: Prisma.ProducerWhereInput;
+  strainWhere?: Prisma.StrainWhereInput;
+  attributeTag?: string;
+};
+
+const createFilters = (
+  attributeTag?: string
+): Pick<StateMetadata, "producerWhere" | "strainWhere"> => {
+  if (!attributeTag) {
+    return { producerWhere: undefined, strainWhere: undefined };
+  }
+
+  const producerWhere: Prisma.ProducerWhereInput = {
+    attributes: { has: attributeTag },
+  };
+
+  const strainWhere: Prisma.StrainWhereInput = {
+    producer: { attributes: { has: attributeTag } },
+  };
+
+  return { producerWhere, strainWhere };
+};
+
+export const STATES: StateMetadata[] = [
+  {
+    slug: "colorado",
+    name: "Colorado",
+    abbreviation: "CO",
+    tagline: "Celebrating the Centennial State's finest producers",
+    attributeTag: "state:colorado",
+    ...createFilters("state:colorado"),
+  },
+];
+
+export const DEFAULT_STATE = STATES[0];
+export const DEFAULT_STATE_SLUG = DEFAULT_STATE.slug;
+
+export function getStateMetadata(stateName: string): StateMetadata | null {
+  const normalized = stateName.toLowerCase();
+  return STATES.find((state) => state.slug === normalized) ?? null;
+}
+
+export function getStateFromAttributes(
+  attributes?: string[] | null
+): StateMetadata {
+  if (attributes) {
+    for (const state of STATES) {
+      if (state.attributeTag && attributes.includes(state.attributeTag)) {
+        return state;
+      }
+    }
+  }
+  return DEFAULT_STATE;
+}
+
+export function generateStateStaticParams() {
+  return STATES.map((state) => ({ stateName: state.slug }));
+}


### PR DESCRIPTION
## Summary
- add state metadata utilities and a dynamic [stateName] layout with state navigation
- move rankings, drops, and producer routes under the state segment and scope Prisma queries by state
- update shared components and sitemap to emit state-prefixed links and navigation defaults

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68cda6f2a858832da976573616816f27