### PR TITLE
Add state model and scoped data seeding

### DIFF
--- a/prisma/migrations/20251001120000_add_states/migration.sql
+++ b/prisma/migrations/20251001120000_add_states/migration.sql
@@ -1,0 +1,85 @@
+-- Create State table
+CREATE TABLE "State" (
+    "id"   TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    CONSTRAINT "State_pkey" PRIMARY KEY ("id")
+);
+
+-- Ensure codes and slugs are unique
+CREATE UNIQUE INDEX "State_code_key" ON "State"("code");
+CREATE UNIQUE INDEX "State_slug_key" ON "State"("slug");
+
+-- Seed default Colorado state
+INSERT INTO "State" ("id", "code", "name", "slug")
+VALUES ('state_co_default', 'CO', 'Colorado', 'colorado')
+ON CONFLICT ("code") DO NOTHING;
+
+-- Producers gain a state reference
+ALTER TABLE "Producer" ADD COLUMN "stateId" TEXT;
+
+UPDATE "Producer"
+SET "stateId" = (SELECT "id" FROM "State" WHERE "code" = 'CO')
+WHERE "stateId" IS NULL;
+
+ALTER TABLE "Producer"
+ALTER COLUMN "stateId" SET NOT NULL;
+
+ALTER TABLE "Producer"
+ADD CONSTRAINT "Producer_stateId_fkey" FOREIGN KEY ("stateId") REFERENCES "State"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Refresh producer uniqueness constraints for state scoping
+DROP INDEX IF EXISTS "Producer_name_category_key";
+DROP INDEX IF EXISTS "Producer_slug_key";
+CREATE UNIQUE INDEX "Producer_stateId_name_category_key" ON "Producer"("stateId", "name", "category");
+CREATE UNIQUE INDEX "Producer_stateId_slug_key" ON "Producer"("stateId", "slug");
+CREATE INDEX "Producer_stateId_idx" ON "Producer"("stateId");
+
+-- Strains gain a state reference
+ALTER TABLE "Strain" ADD COLUMN "stateId" TEXT;
+
+UPDATE "Strain" s
+SET "stateId" = p."stateId"
+FROM "Producer" p
+WHERE s."producerId" = p."id" AND s."stateId" IS NULL;
+
+ALTER TABLE "Strain"
+ALTER COLUMN "stateId" SET NOT NULL;
+
+ALTER TABLE "Strain"
+ADD CONSTRAINT "Strain_stateId_fkey" FOREIGN KEY ("stateId") REFERENCES "State"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX "Strain_stateId_idx" ON "Strain"("stateId");
+
+-- Votes gain a state reference
+ALTER TABLE "Vote" ADD COLUMN "stateId" TEXT;
+
+UPDATE "Vote" v
+SET "stateId" = p."stateId"
+FROM "Producer" p
+WHERE v."producerId" = p."id" AND v."stateId" IS NULL;
+
+ALTER TABLE "Vote"
+ALTER COLUMN "stateId" SET NOT NULL;
+
+ALTER TABLE "Vote"
+ADD CONSTRAINT "Vote_stateId_fkey" FOREIGN KEY ("stateId") REFERENCES "State"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX "Vote_stateId_idx" ON "Vote"("stateId");
+
+-- Producer rating snapshots gain a state reference
+ALTER TABLE "ProducerRatingSnapshot" ADD COLUMN "stateId" TEXT;
+
+UPDATE "ProducerRatingSnapshot" prs
+SET "stateId" = p."stateId"
+FROM "Producer" p
+WHERE prs."producerId" = p."id" AND prs."stateId" IS NULL;
+
+ALTER TABLE "ProducerRatingSnapshot"
+ALTER COLUMN "stateId" SET NOT NULL;
+
+ALTER TABLE "ProducerRatingSnapshot"
+ADD CONSTRAINT "ProducerRatingSnapshot_stateId_fkey" FOREIGN KEY ("stateId") REFERENCES "State"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX "ProducerRatingSnapshot_stateId_createdAt_idx" ON "ProducerRatingSnapshot"("stateId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,18 @@ enum Category {
   HASH
 }
 
+model State {
+  id    String @id @default(cuid())
+  code  String @unique
+  name  String
+  slug  String @unique
+
+  producers              Producer[]
+  strains                Strain[]
+  votes                  Vote[]
+  producerRatingSnapshots ProducerRatingSnapshot[]
+}
+
 model User {
   id                String          @id @default(cuid()) // Reverted to CUID
   name              String?
@@ -43,12 +55,14 @@ model Producer {
   id                     String                   @id @default(cuid())
   name                   String
   category               Category
+  state                  State                    @relation(fields: [stateId], references: [id])
+  stateId                String
   logoUrl                String?
   profileImage           String?
   website                String?
   ingredients            String?
   attributes             String[]                 @default([])
-  slug                   String?                  @unique
+  slug                   String?
   createdAt              DateTime                 @default(now())
   createdBy              User?                    @relation(fields: [createdById], references: [id])
   createdById            String?
@@ -59,7 +73,9 @@ model Producer {
   strains                Strain[]
   StrainReview           StrainReview[]
 
-  @@unique([name, category])
+  @@unique([stateId, name, category])
+  @@unique([stateId, slug])
+  @@index([stateId])
 }
 
 model Vote {
@@ -68,11 +84,14 @@ model Vote {
   userId     String
   producer   Producer @relation(fields: [producerId], references: [id], onDelete: Cascade) // Added onDelete: Cascade
   producerId String
+  state      State    @relation(fields: [stateId], references: [id])
+  stateId    String
   value      Int // rating 1-5
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt // Added missing updatedAt
 
   @@unique([userId, producerId])
+  @@index([stateId])
 }
 
 model Comment {
@@ -93,11 +112,14 @@ model ProducerRatingSnapshot {
   id            String   @id @default(cuid())
   producer      Producer @relation(fields: [producerId], references: [id], onDelete: Cascade)
   producerId    String
+  state         State    @relation(fields: [stateId], references: [id])
+  stateId       String
   averageRating Float
   categoryRank  Int
   createdAt     DateTime @default(now())
 
   @@index([producerId, createdAt])
+  @@index([stateId, createdAt])
 }
 
 model ProducerAdmin {
@@ -118,11 +140,14 @@ model Strain {
   imageUrl     String?
   producer     Producer       @relation(fields: [producerId], references: [id], onDelete: Cascade)
   producerId   String
+  state        State          @relation(fields: [stateId], references: [id])
+  stateId      String
   createdAt    DateTime       @default(now())
   updatedAt    DateTime       @updatedAt
   StrainReview StrainReview[]
 
   @@unique([producerId, name])
+  @@index([stateId])
 }
 
 model StrainReview {

--- a/src/app/[stateName]/drops/[producerSlug]/page.tsx
+++ b/src/app/[stateName]/drops/[producerSlug]/page.tsx
@@ -26,7 +26,7 @@ export default async function DropsByProducerPage({
   params,
 }: DropsByProducerPageProps) {
   const { stateName, producerSlug } = await params;
-  const state = getStateMetadata(stateName);
+  const state = await getStateMetadata(stateName);
 
   if (!state) {
     notFound();

--- a/src/app/[stateName]/drops/page.tsx
+++ b/src/app/[stateName]/drops/page.tsx
@@ -17,7 +17,7 @@ export default async function DropsPage({
   params: Promise<{ stateName: string }>;
 }) {
   const { stateName } = await params;
-  const state = getStateMetadata(stateName);
+  const state = await getStateMetadata(stateName);
 
   if (!state) {
     notFound();

--- a/src/app/[stateName]/layout.tsx
+++ b/src/app/[stateName]/layout.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/lib/states";
 import { StateProvider } from "@/components/StateProvider";
 
-export function generateStaticParams() {
+export async function generateStaticParams() {
   return generateStateStaticParams();
 }
 
@@ -18,7 +18,7 @@ export default async function StateLayout({
   params: Promise<{ stateName: string }>;
 }) {
   const { stateName } = await params;
-  const state = getStateMetadata(stateName);
+  const state = await getStateMetadata(stateName);
 
   if (!state) {
     notFound();

--- a/src/app/[stateName]/producer/[slug]/[strainSlug]/page.tsx
+++ b/src/app/[stateName]/producer/[slug]/[strainSlug]/page.tsx
@@ -78,7 +78,7 @@ function ExpandableReviewSection({
 
 export default async function StrainPage({ params }: StrainPageProps) {
   const { stateName, slug: producerSlug, strainSlug } = await params;
-  const state = getStateMetadata(stateName);
+  const state = await getStateMetadata(stateName);
 
   if (!state) {
     notFound();

--- a/src/app/[stateName]/producer/[slug]/page.tsx
+++ b/src/app/[stateName]/producer/[slug]/page.tsx
@@ -31,7 +31,7 @@ export default async function ProducerProfilePage({
   params,
 }: ProducerProfilePageProps) {
   const { stateName, slug } = await params;
-  const state = getStateMetadata(stateName);
+  const state = await getStateMetadata(stateName);
 
   if (!state) {
     notFound();

--- a/src/app/[stateName]/producer/[slug]/strains/page.tsx
+++ b/src/app/[stateName]/producer/[slug]/strains/page.tsx
@@ -15,7 +15,7 @@ export default async function ProducerStrainsPage({
   params,
 }: ProducerStrainsPageProps) {
   const { stateName, slug } = await params;
-  const state = getStateMetadata(stateName);
+  const state = await getStateMetadata(stateName);
 
   if (!state) {
     notFound();

--- a/src/app/[stateName]/rankings/page.tsx
+++ b/src/app/[stateName]/rankings/page.tsx
@@ -24,7 +24,7 @@ export default async function RankingsPage({
   searchParams: Promise<{ view?: string }>;
 }) {
   const { stateName } = await params;
-  const state = getStateMetadata(stateName);
+  const state = await getStateMetadata(stateName);
 
   if (!state) {
     notFound();

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -16,7 +16,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
-import { DEFAULT_STATE_SLUG } from "@/lib/states";
+import { DEFAULT_STATE_SLUG } from "@/lib/stateConstants";
 
 export default function AboutPage() {
   return (

--- a/src/app/api/admin/create-producer/route.ts
+++ b/src/app/api/admin/create-producer/route.ts
@@ -36,7 +36,16 @@ export async function POST(request: Request) {
     attributes,
     slug,
     profileImage,
+    stateCode,
   } = await request.json();
+
+  const state = await prisma.state.findUnique({
+    where: { code: typeof stateCode === "string" ? stateCode : "CO" },
+  });
+
+  if (!state) {
+    return NextResponse.json({ error: "Invalid state" }, { status: 400 });
+  }
   await prisma.producer.create({
     data: {
       name,
@@ -47,6 +56,7 @@ export async function POST(request: Request) {
       slug,
       profileImage,
       createdById: user.id,
+      stateId: state.id,
     },
   });
   return NextResponse.json({ ok: true });

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -22,7 +22,17 @@ export async function GET(request: NextRequest) {
 
   const comments = await prisma.comment.findMany({
     where,
-    include: { user: true },
+    include: {
+      user: true,
+      producer: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          state: { select: { slug: true } },
+        },
+      },
+    },
     orderBy: { updatedAt: "desc" },
   });
 
@@ -82,6 +92,17 @@ export async function POST(request: NextRequest) {
     update: {
       text,
       imageUrls: images,
+    },
+    include: {
+      user: true,
+      producer: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          state: { select: { slug: true } },
+        },
+      },
     },
   });
 

--- a/src/app/api/states/route.ts
+++ b/src/app/api/states/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getAllStateMetadata } from "@/lib/states";
+
+export async function GET() {
+  try {
+    const states = await getAllStateMetadata();
+    return NextResponse.json({
+      success: true,
+      states: states.map(({ slug, name, abbreviation }) => ({
+        slug,
+        name,
+        abbreviation,
+      })),
+    });
+  } catch (error) {
+    console.error("[/api/states] failed to load states", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to load states" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/strains/route.ts
+++ b/src/app/api/strains/route.ts
@@ -91,9 +91,19 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    const producer = await prisma.producer.findUnique({
+      where: { id: body.producerId },
+      select: { stateId: true },
+    });
+
+    if (!producer) {
+      return NextResponse.json({ success: false, error: "Producer not found" }, { status: 404 });
+    }
+
     const strain = await prisma.strain.create({
       data: {
         producerId: body.producerId,
+        stateId: producer.stateId,
         name: body.name,
         description: body.description,
         imageUrl: body.imageUrl,

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
-import { DEFAULT_STATE_SLUG } from "@/lib/states";
+import { DEFAULT_STATE_SLUG } from "@/lib/stateConstants";
 
 function LoginForm() {
   const router = useRouter();

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -12,8 +12,8 @@ import { cookies } from "next/headers";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { Instagram, ExternalLink, Link as LinkIcon } from "lucide-react";
 import ProducerCard from "@/components/ProducerCard";
-import { getStateFromAttributes } from "@/lib/states";
 import { StateProvider } from "@/components/StateProvider";
+import { DEFAULT_STATE_SLUG } from "@/lib/stateConstants";
 
 export const dynamic = "force-dynamic";
 
@@ -49,15 +49,23 @@ export default async function ProfilePage({
     include: {
       votes: {
         // producer.votes is needed for ProducerCard to calculate total score
-        include: { producer: { include: { votes: true, _count: { select: { comments: true } } } } },
+        include: {
+          producer: {
+            include: {
+              votes: true,
+              _count: { select: { comments: true } },
+              state: true,
+            },
+          },
+        },
       },
       comments: {
-        include: { producer: true, user: true },
+        include: { producer: { include: { state: true } }, user: true },
         orderBy: { updatedAt: "desc" },
       },
       StrainReview: {
         include: {
-          strain: { include: { producer: true } },
+          strain: { include: { producer: { include: { state: true } } } },
           user: {
             select: {
               id: true,
@@ -77,16 +85,24 @@ export default async function ProfilePage({
     user = await prisma.user.findUnique({
       where: { id },
       include: {
-        votes: {
-          include: { producer: { include: { votes: true, _count: { select: { comments: true } } } } },
+      votes: {
+        include: {
+          producer: {
+            include: {
+              votes: true,
+              _count: { select: { comments: true } },
+              state: true,
+            },
+          },
         },
-        comments: {
-          include: { producer: true, user: true },
-          orderBy: { updatedAt: "desc" },
-        },
-        StrainReview: {
-          include: {
-            strain: { include: { producer: true } },
+      },
+      comments: {
+        include: { producer: { include: { state: true } }, user: true },
+        orderBy: { updatedAt: "desc" },
+      },
+      StrainReview: {
+        include: {
+          strain: { include: { producer: { include: { state: true } } } },
             user: {
               select: {
                 id: true,
@@ -247,14 +263,18 @@ export default async function ProfilePage({
         <div className="space-y-8">
           {/* Comments Section */}
           <ExpandableSection title="Comments" count={user.comments.length} initialShowCount={5}>
-            {user.comments.map((c) => (
-              <CommentCard 
-                key={c.id} 
-                comment={c} 
-                currentUserId={currentViewerId} 
-                showRating={false} 
-              />
-            ))}
+            {user.comments.map((c) => {
+              const stateSlug = c.producer?.state?.slug ?? DEFAULT_STATE_SLUG;
+              return (
+                <StateProvider key={c.id} stateSlug={stateSlug}>
+                  <CommentCard
+                    comment={c}
+                    currentUserId={currentViewerId}
+                    showRating={false}
+                  />
+                </StateProvider>
+              );
+            })}
           </ExpandableSection>
 
           {/* Rated Producers Section
@@ -270,10 +290,10 @@ export default async function ProfilePage({
                 const j = rank % 10;
                 const k = rank % 100;
                 const suffix = j === 1 && k !== 11 ? "st" : j === 2 && k !== 12 ? "nd" : j === 3 && k !== 13 ? "rd" : "th";
-                const producerState = getStateFromAttributes(producer.attributes);
+                const stateSlug = producer.state?.slug ?? DEFAULT_STATE_SLUG;
 
                 return (
-                  <StateProvider key={producer.id} stateSlug={producerState.slug}>
+                  <StateProvider key={producer.id} stateSlug={stateSlug}>
                     <ProducerCard
                       rank={rank}
                       rankSuffix={suffix}
@@ -292,9 +312,8 @@ export default async function ProfilePage({
           {/* Strain Reviews Section */}
           <ExpandableSection title="Strain Reviews" count={user.StrainReview.length} initialShowCount={4}>
             {user.StrainReview.map((review) => {
-              const producerState = getStateFromAttributes(
-                review.strain.producer.attributes
-              );
+              const stateSlug =
+                review.strain.producer.state?.slug ?? DEFAULT_STATE_SLUG;
               const producerSlug =
                 review.strain.producer.slug ?? review.strain.producer.id;
 
@@ -304,7 +323,7 @@ export default async function ProfilePage({
                   className="bg-gradient-to-r from-green-50 to-emerald-50 rounded-xl p-4 border border-green-100"
                 >
                   <Link
-                    href={`/${producerState.slug}/producer/${producerSlug}/${review.strain.strainSlug}`}
+                    href={`/${stateSlug}/producer/${producerSlug}/${review.strain.strainSlug}`}
                     className="inline-block text-xl font-semibold text-green-700 hover:text-green-800 transition-colors mb-3 hover:underline"
                   >
                     {review.strain.name}

--- a/src/components/AddProducerForm.tsx
+++ b/src/components/AddProducerForm.tsx
@@ -34,6 +34,7 @@ export default function AddProducerForm({
       slug,
       profileImage,
       attributes,
+      stateCode: "CO",
     };
     if (producer) {
       await fetch(`/api/producers/${producer.id}`, {

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -23,7 +23,12 @@ export interface CommentData {
   userId: string;
   producerId: string;
   updatedAt: string | Date;
-  producer?: { id: string; name: string; slug: string | null };
+  producer?: {
+    id: string;
+    name: string;
+    slug: string | null;
+    state?: { slug: string } | null;
+  };
   voteValue?: number | null;
 }
 

--- a/src/components/HeroHome.tsx
+++ b/src/components/HeroHome.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from "react";
 import { motion, useAnimation, useScroll, useTransform } from "framer-motion";
 import { ChevronRight, Star, Users, TrendingUp, Cannabis } from "lucide-react";
 import Link from "next/link";
-import { DEFAULT_STATE_SLUG } from "@/lib/states";
+import { DEFAULT_STATE_SLUG } from "@/lib/stateConstants";
 import Image from "next/image";
 
 export default function HeroHome() {

--- a/src/components/ProducerList.tsx
+++ b/src/components/ProducerList.tsx
@@ -13,6 +13,7 @@ export type ProducerWithVotes = Producer & {
   votes: Vote[];
   attributes: string[];
   _count?: { comments: number };
+  state?: { slug: string } | null;
 };
 
 interface Props {

--- a/src/components/StateProvider.tsx
+++ b/src/components/StateProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext } from "react";
-import { DEFAULT_STATE_SLUG } from "@/lib/states";
+import { DEFAULT_STATE_SLUG } from "@/lib/stateConstants";
 
 const StateSlugContext = createContext<string>(DEFAULT_STATE_SLUG);
 

--- a/src/components/VoteButton.tsx
+++ b/src/components/VoteButton.tsx
@@ -62,7 +62,7 @@ export default function VoteButton({
     const res = await fetch("/api/vote", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ producerId, value: val }),
+      body: JSON.stringify({ producerId, value: val, stateSlug }),
     });
     if (res.ok) {
       setShowTooltip(true);

--- a/src/lib/stateConstants.ts
+++ b/src/lib/stateConstants.ts
@@ -1,0 +1,10 @@
+export const DEFAULT_STATE_SLUG = "colorado";
+export const DEFAULT_STATE = {
+  slug: DEFAULT_STATE_SLUG,
+  name: "Colorado",
+  abbreviation: "CO",
+};
+
+export const STATE_TAGLINES: Record<string, string> = {
+  colorado: "Celebrating the Centennial State's finest producers",
+};


### PR DESCRIPTION
## Summary
- add a State model and connect producers, votes, strains, and rating snapshots to states with supporting indexes
- create a migration that backfills current records into a default Colorado state and enforces new constraints
- extend the seed script and ranking/back-office flows to seed the target state list and honor the new state relationships

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68ce000b004c832db717558d7aeeb48a