### PR TITLE
Require state selection and validate state routes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,105 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+const NON_STATE_SEGMENTS = new Set([
+  "about",
+  "admin",
+  "error",
+  "faq",
+  "feedback",
+  "login",
+  "not-found",
+  "privacy",
+  "profile",
+  "signup",
+  "terms",
+]);
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+let cachedStates: { expires: number; slugs: Set<string> } | null = null;
+
+async function getStateSlugs(request: NextRequest): Promise<Set<string> | null> {
+  if (cachedStates && cachedStates.expires > Date.now()) {
+    return cachedStates.slugs;
+  }
+
+  try {
+    const response = await fetch(new URL("/api/states", request.url), {
+      headers: {
+        "x-middleware-fetch": "1",
+      },
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      success: boolean;
+      states?: { slug: string }[];
+    };
+
+    if (!data.success || !data.states) {
+      return null;
+    }
+
+    const slugs = new Set(
+      data.states
+        .map((state) => state.slug.toLowerCase())
+        .filter((slug) => slug && typeof slug === "string"),
+    );
+
+    cachedStates = {
+      expires: Date.now() + CACHE_TTL_MS,
+      slugs,
+    };
+
+    return slugs;
+  } catch {
+    return null;
+  }
+}
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (pathname === "/" || pathname === "") {
+    return NextResponse.next();
+  }
+
+  const segments = pathname.split("/").filter(Boolean);
+
+  if (!segments.length) {
+    return NextResponse.next();
+  }
+
+  const [first] = segments;
+  const normalized = first.toLowerCase();
+
+  if (NON_STATE_SEGMENTS.has(normalized) || normalized.startsWith("_")) {
+    return NextResponse.next();
+  }
+
+  if (normalized.includes(".")) {
+    return NextResponse.next();
+  }
+
+  const stateSlugs = await getStateSlugs(request);
+
+  if (!stateSlugs || !stateSlugs.size) {
+    return NextResponse.next();
+  }
+
+  if (stateSlugs.has(normalized)) {
+    return NextResponse.next();
+  }
+
+  const notFoundUrl = request.nextUrl.clone();
+  notFoundUrl.pathname = "/not-found";
+  return NextResponse.rewrite(notFoundUrl);
+}
+
+export const config = {
+  matcher: ["/((?!api|_next|static|.*\\..*).*)"],
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,14 +2,36 @@
 import { cookies } from "next/headers";
 import AgeGate from "@/components/AgeGate";
 import HeroHome from "@/components/HeroHome";
+import { getAllStateMetadata } from "@/lib/states";
+
+const STATE_COOKIE_NAME = "preferredState";
 
 export default async function HomePage() {
   const cookieStore = await cookies();
   const is21 = cookieStore.get("ageVerify")?.value === "true";
+  const preferredState = cookieStore.get(STATE_COOKIE_NAME)?.value ?? null;
 
-  if (!is21) {
-    return <AgeGate />;
+  const states = await getAllStateMetadata();
+  const serializableStates = states.map((state) => ({
+    slug: state.slug,
+    name: state.name,
+    abbreviation: state.abbreviation,
+    tagline: state.tagline,
+  }));
+
+  const selectedState =
+    preferredState && serializableStates.length
+      ? serializableStates.find((state) => state.slug === preferredState) ?? null
+      : null;
+
+  if (!is21 || !selectedState) {
+    return (
+      <AgeGate
+        states={serializableStates}
+        initialStateSlug={preferredState}
+      />
+    );
   }
 
-  return <HeroHome />;
+  return <HeroHome state={selectedState} />;
 }

--- a/src/components/AgeGate.tsx
+++ b/src/components/AgeGate.tsx
@@ -1,149 +1,333 @@
 "use client";
 
-import type { ChangeEvent } from "react";
-import { useCallback, useMemo, useState } from "react";
-import { CheckCircle2, ShieldCheck } from "lucide-react";
+import { useState, useEffect, type ChangeEvent, type ReactNode } from "react";
+import { Shield, Calendar, Cookie, Eye, Lock, Check, Leaf } from "lucide-react";
 
 export type AgeGateStateOption = {
   slug: string;
   name: string;
   abbreviation: string;
-  tagline?: string;
+  tagline?: string | null;
 };
+
+type Step = "age" | "privacy" | "complete";
+
+interface CookiePreferences {
+  essential: boolean;
+  analytics: boolean;
+  marketing: boolean;
+  functional: boolean;
+}
+
+type CookieType = keyof Omit<CookiePreferences, "essential">;
+
+interface ModalProps {
+  isOpen: boolean;
+  children: ReactNode;
+}
+
+const AGE_COOKIE_NAME = "ageVerify";
+const PRIVACY_COOKIE_NAME = "privacyConsent";
+const COOKIE_PREFS_COOKIE_NAME = "cookiePreferences";
+const STATE_COOKIE_NAME = "preferredState";
+const STATE_STORAGE_KEY = "terptier:selectedState";
+
+const setCookie = (name: string, value: string, days: number): void => {
+  const expires = new Date();
+  expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000);
+  document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/;SameSite=Lax`;
+};
+
+const getCookie = (name: string): string | null => {
+  const nameEQ = `${name}=`;
+  const cookies = document.cookie.split(";");
+  for (let i = 0; i < cookies.length; i += 1) {
+    let cookie = cookies[i];
+    while (cookie.charAt(0) === " ") {
+      cookie = cookie.substring(1, cookie.length);
+    }
+    if (cookie.indexOf(nameEQ) === 0) {
+      return cookie.substring(nameEQ.length, cookie.length);
+    }
+  }
+  return null;
+};
+
+const deleteCookie = (name: string): void => {
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+};
+
+function Modal({ isOpen, children }: ModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50">
+      <div className="bg-white/95 backdrop-blur-xl rounded-3xl shadow-2xl w-full max-w-lg mx-4 max-h-[95vh] overflow-y-auto border border-green-200/30">
+        {children}
+      </div>
+    </div>
+  );
+}
 
 interface AgeGateProps {
   states?: AgeGateStateOption[];
   initialStateSlug?: string | null;
 }
 
-const AGE_COOKIE_NAME = "ageVerify";
-const STATE_COOKIE_NAME = "preferredState";
-const STATE_STORAGE_KEY = "terptier:selectedState";
-
-const setCookie = (name: string, value: string, maxAgeDays: number) => {
-  const expires = new Date();
-  expires.setDate(expires.getDate() + maxAgeDays);
-  document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/;SameSite=Lax`;
-};
-
-export default function AgeGate({
-  states = [],
-  initialStateSlug = null,
-}: AgeGateProps) {
-  const hasStates = states.length > 0;
-  const initialSelection = useMemo(() => {
-    if (!hasStates) {
+export default function AgeGate({ states = [], initialStateSlug = null }: AgeGateProps) {
+  const normalizedInitialSlug = initialStateSlug?.toLowerCase() ?? "";
+  const [open, setOpen] = useState<boolean>(true);
+  const [step, setStep] = useState<Step>("age");
+  const [cookiePreferences, setCookiePreferences] = useState<CookiePreferences>({
+    essential: true,
+    analytics: false,
+    marketing: false,
+    functional: false,
+  });
+  const [showCookieDetails, setShowCookieDetails] = useState<boolean>(false);
+  const [selectedState, setSelectedState] = useState<string>(() => {
+    if (!states.length) {
       return "";
     }
-    if (!initialStateSlug) {
-      return "";
+    if (normalizedInitialSlug && states.some((state) => state.slug === normalizedInitialSlug)) {
+      return normalizedInitialSlug;
     }
-    const normalized = initialStateSlug.toLowerCase();
-    return states.some((state) => state.slug === normalized) ? normalized : "";
-  }, [hasStates, initialStateSlug, states]);
+    return "";
+  });
+  const [stateError, setStateError] = useState<string | null>(null);
+  const [hasExistingPrivacyConsent, setHasExistingPrivacyConsent] = useState(false);
 
-  const [is21Confirmed, setIs21Confirmed] = useState(false);
-  const [selectedState, setSelectedState] = useState(initialSelection);
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [complete, setComplete] = useState(false);
-
-  const handleStateChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
-    setSelectedState(event.target.value);
-    if (error) {
-      setError(null);
-    }
-  }, [error]);
-
-  const handleConfirm = async () => {
-    if (submitting) {
+  useEffect(() => {
+    if (!states.length) {
       return;
     }
 
-    if (!is21Confirmed) {
-      setError("You must confirm that you are 21 or older to continue.");
-      return;
-    }
+    const initialFromProps = normalizedInitialSlug && states.some((state) => state.slug === normalizedInitialSlug)
+      ? normalizedInitialSlug
+      : "";
 
-    if (hasStates && !selectedState) {
-      setError("Please select your state before continuing.");
-      return;
-    }
+    const cookieState = getCookie(STATE_COOKIE_NAME);
+    const hasCookieState = cookieState && states.some((state) => state.slug === cookieState);
 
-    setSubmitting(true);
-    setError(null);
-
-    setCookie(AGE_COOKIE_NAME, "true", 30);
-
-    if (hasStates && selectedState) {
-      setCookie(STATE_COOKIE_NAME, selectedState, 365);
+    if (hasCookieState) {
+      setSelectedState(cookieState!);
       try {
-        window.localStorage.setItem(STATE_STORAGE_KEY, selectedState);
-      } catch (storageError) {
-        console.warn("Unable to persist state selection", storageError);
+        window.localStorage.setItem(STATE_STORAGE_KEY, cookieState!);
+      } catch (error) {
+        console.warn("Unable to persist state selection", error);
+      }
+    } else if (initialFromProps) {
+      setSelectedState(initialFromProps);
+    } else if (typeof window !== "undefined") {
+      try {
+        const stored = window.localStorage.getItem(STATE_STORAGE_KEY);
+        if (stored && states.some((state) => state.slug === stored)) {
+          setSelectedState(stored);
+        }
+      } catch (error) {
+        console.warn("Unable to load stored state selection", error);
+      }
+    }
+  }, [states, normalizedInitialSlug]);
+
+  useEffect(() => {
+    const ageVerifyCookie = getCookie(AGE_COOKIE_NAME);
+    const privacyConsent = getCookie(PRIVACY_COOKIE_NAME);
+    const cookiePrefs = getCookie(COOKIE_PREFS_COOKIE_NAME);
+
+    if (cookiePrefs) {
+      try {
+        const parsed = JSON.parse(decodeURIComponent(cookiePrefs));
+        setCookiePreferences((prev) => ({ ...prev, ...parsed }));
+      } catch (error) {
+        console.error("Error parsing cookie preferences:", error);
       }
     }
 
-    setComplete(true);
+    const cookieState = getCookie(STATE_COOKIE_NAME);
+    const hasValidState = !states.length || (cookieState && states.some((state) => state.slug === cookieState));
 
-    window.setTimeout(() => {
+    if (privacyConsent === "true") {
+      setHasExistingPrivacyConsent(true);
+    }
+
+    if (ageVerifyCookie === "true" && hasValidState) {
+      if (privacyConsent === "true") {
+        setStep("complete");
+        setTimeout(() => {
+          setOpen(false);
+          window.location.reload();
+        }, 1200);
+      } else {
+        setStep("privacy");
+      }
+    }
+  }, [states]);
+
+  const persistStateSelection = (slug: string) => {
+    setCookie(STATE_COOKIE_NAME, slug, 365);
+    try {
+      window.localStorage.setItem(STATE_STORAGE_KEY, slug);
+    } catch (error) {
+      console.warn("Unable to persist state selection", error);
+    }
+  };
+
+  const handleAgeConfirm = (): void => {
+    if (states.length && !selectedState) {
+      setStateError("Please select your state to continue.");
+      return;
+    }
+
+    setCookie(AGE_COOKIE_NAME, "true", 30);
+
+    if (states.length && selectedState) {
+      persistStateSelection(selectedState);
+    }
+
+    if (hasExistingPrivacyConsent) {
+      setStep("complete");
+      setTimeout(() => {
+        setOpen(false);
+        window.location.reload();
+      }, 1200);
+    } else {
+      setStep("privacy");
+    }
+  };
+
+  const handlePrivacyAccept = (): void => {
+    setHasExistingPrivacyConsent(true);
+    setStep("complete");
+
+    setCookie(PRIVACY_COOKIE_NAME, "true", 365);
+    setCookie(COOKIE_PREFS_COOKIE_NAME, encodeURIComponent(JSON.stringify(cookiePreferences)), 365);
+
+    if (states.length && selectedState) {
+      persistStateSelection(selectedState);
+    }
+
+    if (cookiePreferences.analytics) {
+      setCookie("analyticsEnabled", "true", 365);
+    } else {
+      deleteCookie("analyticsEnabled");
+    }
+
+    if (cookiePreferences.marketing) {
+      setCookie("marketingEnabled", "true", 365);
+    } else {
+      deleteCookie("marketingEnabled");
+    }
+
+    if (cookiePreferences.functional) {
+      setCookie("functionalEnabled", "true", 365);
+    } else {
+      deleteCookie("functionalEnabled");
+    }
+
+    setTimeout(() => {
+      setOpen(false);
       window.location.reload();
-    }, 800);
+    }, 2000);
+  };
+
+  const toggleCookiePreference = (type: CookieType): void => {
+    setCookiePreferences((prev) => ({
+      ...prev,
+      [type]: !prev[type],
+    }));
+  };
+
+  const handleRejectAll = (): void => {
+    setCookiePreferences({
+      essential: true,
+      analytics: false,
+      marketing: false,
+      functional: false,
+    });
+  };
+
+  const handleAcceptAll = (): void => {
+    setCookiePreferences({
+      essential: true,
+      analytics: true,
+      marketing: true,
+      functional: true,
+    });
+  };
+
+  const handleStateChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setSelectedState(event.target.value);
+    if (stateError) {
+      setStateError(null);
+    }
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 backdrop-blur-sm p-4">
-      <div className="w-full max-w-xl rounded-3xl bg-white/95 p-8 shadow-2xl">
-        {complete ? (
-          <div className="flex flex-col items-center text-center space-y-4">
-            <CheckCircle2 className="h-16 w-16 text-emerald-500" />
-            <h2 className="text-2xl font-semibold text-slate-900">Welcome to TerpTier</h2>
-            <p className="text-slate-600">
-              Thank you for verifying your age{hasStates ? " and selecting your state" : ""}. Loading your experience now.
-            </p>
+    <Modal isOpen={open}>
+      {step === "complete" ? (
+        <div className="p-6 sm:p-8 text-center">
+          <div className="w-12 h-12 sm:w-16 sm:h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <Check className="w-6 h-6 sm:w-8 sm:h-8 text-green-600" />
           </div>
-        ) : (
-          <div className="space-y-6">
-            <div className="flex items-center space-x-3">
-              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100">
-                <ShieldCheck className="h-7 w-7 text-emerald-600" />
-              </div>
-              <div>
-                <h2 className="text-xl font-semibold text-slate-900">Before we continue</h2>
-                <p className="text-sm text-slate-600">
-                  Please verify that you are at least 21 years old{hasStates ? " and tell us where you're exploring from." : "."}
-                </p>
-              </div>
+          <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-2">Welcome!</h2>
+          <p className="text-gray-600 mb-4 text-sm sm:text-base">
+            Thank you for verifying your age{states.length ? " and setting your state preferences" : ""}.
+          </p>
+          <div className="flex items-center justify-center space-x-2 text-sm text-green-600">
+            <Leaf className="w-4 h-4" />
+            <span>Preferences saved securely</span>
+          </div>
+          <div className="mt-4">
+            <div className="h-2 bg-green-200 rounded-full overflow-hidden">
+              <div className="h-full bg-green-600 rounded-full animate-[loading_2s_ease-in-out]" />
+            </div>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="bg-gradient-to-r from-green-600 to-emerald-600 p-4 sm:p-6 text-white">
+            <div className="flex items-center justify-center mb-3">
+              {step === "age" ? (
+                <Shield className="w-6 h-6 sm:w-8 sm:h-8 mr-2 sm:mr-3" />
+              ) : (
+                <Lock className="w-6 h-6 sm:w-8 sm:h-8 mr-2 sm:mr-3" />
+              )}
+              <h1 className="text-lg sm:text-2xl font-bold">
+                {step === "age" ? "Age Verification" : "Privacy & Cookies"}
+              </h1>
             </div>
 
-            <div className="space-y-4">
-              <label className="flex items-center space-x-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-emerald-300">
-                <input
-                  type="checkbox"
-                  checked={is21Confirmed}
-                  onChange={(event) => {
-                    setIs21Confirmed(event.target.checked);
-                    if (error) {
-                      setError(null);
-                    }
-                  }}
-                  className="h-5 w-5 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
-                />
-                <span className="text-sm font-medium text-slate-800">
-                  I confirm that I am at least 21 years old.
-                </span>
-              </label>
+            <div className="w-full bg-white/20 rounded-full h-2">
+              <div
+                className="bg-white h-2 rounded-full transition-all duration-500 ease-out"
+                style={{ width: step === "age" ? "50%" : "100%" }}
+              />
+            </div>
+          </div>
 
-              {hasStates ? (
-                <div className="space-y-2">
-                  <label htmlFor="state-select" className="text-sm font-medium text-slate-700">
+          {step === "age" && (
+            <div className="p-4 sm:p-8">
+              <div className="text-center mb-6 sm:mb-8">
+                <div className="w-16 h-16 sm:w-20 sm:h-20 bg-gradient-to-br from-green-100 to-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                  <Calendar className="w-8 h-8 sm:w-10 sm:h-10 text-green-600" />
+                </div>
+                <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-3">Age Verification Required</h2>
+                <p className="text-gray-600 text-sm sm:text-lg leading-relaxed px-2">
+                  To access this content, you must be <strong>21 years or older</strong>. Please confirm your age and let us know where you're exploring from to continue.
+                </p>
+              </div>
+
+              {states.length ? (
+                <div className="mb-4 text-left">
+                  <label htmlFor="age-gate-state" className="block text-sm font-semibold text-gray-700 mb-2">
                     Select your state
                   </label>
                   <select
-                    id="state-select"
+                    id="age-gate-state"
                     value={selectedState}
                     onChange={handleStateChange}
-                    className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 shadow-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                    className="w-full rounded-xl border border-green-200 bg-white px-4 py-3 text-sm text-gray-800 shadow-sm focus:border-green-400 focus:outline-none focus:ring-2 focus:ring-green-200"
                   >
                     <option value="" disabled>
                       Choose a state
@@ -154,27 +338,184 @@ export default function AgeGate({
                       </option>
                     ))}
                   </select>
+                  {stateError ? (
+                    <p className="mt-2 text-xs text-red-600" role="alert">
+                      {stateError}
+                    </p>
+                  ) : null}
                 </div>
               ) : null}
+
+              <div className="space-y-3 sm:space-y-4">
+                <button
+                  onClick={handleAgeConfirm}
+                  disabled={states.length > 0 && !selectedState}
+                  className="w-full bg-gradient-to-r from-green-600 to-emerald-600 disabled:from-green-400 disabled:to-emerald-400 disabled:cursor-not-allowed hover:from-green-700 hover:to-emerald-700 text-white font-semibold py-3 sm:py-4 px-4 sm:px-6 rounded-xl transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg hover:shadow-xl text-sm sm:text-base"
+                >
+                  ✓ I'm 21 or older
+                </button>
+
+                <button
+                  onClick={() => window.history.back()}
+                  className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium py-3 sm:py-4 px-4 sm:px-6 rounded-xl transition-all duration-200 border border-gray-200 text-sm sm:text-base"
+                >
+                  I'm under 21
+                </button>
+              </div>
+
+              <div className="mt-4 sm:mt-6 text-center">
+                <p className="text-xs text-gray-500">Your verification will be stored for 30 days.</p>
+              </div>
             </div>
+          )}
 
-            {error ? (
-              <p className="text-sm text-rose-600" role="alert">
-                {error}
-              </p>
-            ) : null}
+          {step === "privacy" && (
+            <div className="p-4 sm:p-8">
+              <div className="text-center mb-4 sm:mb-6">
+                <div className="w-12 h-12 sm:w-16 sm:h-16 bg-gradient-to-br from-green-100 to-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                  <Cookie className="w-6 h-6 sm:w-8 sm:h-8 text-green-600" />
+                </div>
+                <h2 className="text-lg sm:text-xl font-bold text-gray-800 mb-2">Privacy & Cookie Preferences</h2>
+                <p className="text-gray-600 text-xs sm:text-sm">
+                  We respect your privacy. Choose your cookie preferences below.
+                </p>
+              </div>
 
-            <button
-              type="button"
-              onClick={handleConfirm}
-              disabled={submitting}
-              className="w-full rounded-full bg-gradient-to-r from-emerald-500 to-emerald-600 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:from-emerald-600 hover:to-emerald-700 disabled:cursor-not-allowed disabled:opacity-70"
-            >
-              {submitting ? "Loading..." : "Enter TerpTier"}
-            </button>
+              <div className="space-y-3 sm:space-y-4 mb-4 sm:mb-6">
+                <div className="flex items-center justify-between p-3 sm:p-4 bg-green-50 rounded-xl border border-green-100">
+                  <div className="flex-1 pr-3">
+                    <h3 className="font-semibold text-gray-800 text-sm sm:text-base">Essential Cookies</h3>
+                    <p className="text-xs sm:text-sm text-gray-600">Required for basic site functionality</p>
+                  </div>
+                  <div className="w-10 h-5 cursor-not-allowed sm:w-12 sm:h-6 bg-green-500 rounded-full flex items-center justify-end px-1">
+                    <div className="w-3 h-3 sm:w-4 sm:h-4 bg-white rounded-full" />
+                  </div>
+                </div>
+
+                <div className="flex items-center justify-between p-3 sm:p-4 bg-gray-50 rounded-xl border">
+                  <div className="flex-1 pr-3">
+                    <h3 className="font-semibold text-gray-800 text-sm sm:text-base">Analytics</h3>
+                    <p className="text-xs sm:text-sm text-gray-600">Help us improve our service</p>
+                  </div>
+                  <button
+                    onClick={() => toggleCookiePreference("analytics")}
+                    className={`w-10 h-5 sm:w-12 sm:h-6 rounded-full flex items-center px-1 transition-all duration-200 ${
+                      cookiePreferences.analytics ? "bg-green-500 justify-end" : "bg-gray-300 justify-start"
+                    }`}
+                    type="button"
+                  >
+                    <div className="w-3 h-3 sm:w-4 sm:h-4 bg-white rounded-full" />
+                  </button>
+                </div>
+
+                <div className="flex items-center justify-between p-3 sm:p-4 bg-gray-50 rounded-xl border">
+                  <div className="flex-1 pr-3">
+                    <h3 className="font-semibold text-gray-800 text-sm sm:text-base">Marketing</h3>
+                    <p className="text-xs sm:text-sm text-gray-600">Personalized content and ads</p>
+                  </div>
+                  <button
+                    onClick={() => toggleCookiePreference("marketing")}
+                    className={`w-10 h-5 sm:w-12 sm:h-6 rounded-full flex items-center px-1 transition-all duration-200 ${
+                      cookiePreferences.marketing ? "bg-green-500 justify-end" : "bg-gray-300 justify-start"
+                    }`}
+                    type="button"
+                  >
+                    <div className="w-3 h-3 sm:w-4 sm:h-4 bg-white rounded-full" />
+                  </button>
+                </div>
+
+                <div className="flex items-center justify-between p-3 sm:p-4 bg-gray-50 rounded-xl border">
+                  <div className="flex-1 pr-3">
+                    <h3 className="font-semibold text-gray-800 text-sm sm:text-base">Functional</h3>
+                    <p className="text-xs sm:text-sm text-gray-600">Experience enhancements</p>
+                  </div>
+                  <button
+                    onClick={() => toggleCookiePreference("functional")}
+                    className={`w-10 h-5 sm:w-12 sm:h-6 rounded-full flex items-center px-1 transition-all duration-200 ${
+                      cookiePreferences.functional ? "bg-green-500 justify-end" : "bg-gray-300 justify-start"
+                    }`}
+                    type="button"
+                  >
+                    <div className="w-3 h-3 sm:w-4 sm:h-4 bg-white rounded-full" />
+                  </button>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <div className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-3">
+                  <button
+                    onClick={handleAcceptAll}
+                    className="flex-1 bg-green-100 hover:bg-green-200 text-green-700 font-semibold py-3 px-4 rounded-xl transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg text-sm border border-green-200"
+                    type="button"
+                  >
+                    Accept All
+                  </button>
+                  <button
+                    onClick={handleRejectAll}
+                    className="flex-1 bg-red-100 hover:bg-red-200 text-red-700 font-medium py-3 px-4 rounded-xl transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg text-sm border border-red-200"
+                    type="button"
+                  >
+                    Reject All
+                  </button>
+                </div>
+
+                <button
+                  onClick={handlePrivacyAccept}
+                  className="w-full bg-gradient-to-r from-emerald-600 to-green-600 hover:from-emerald-700 hover:to-green-700 text-white font-semibold py-3 px-4 sm:px-6 rounded-xl transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg text-sm"
+                  type="button"
+                >
+                  Save My Preferences
+                </button>
+
+                <button
+                  onClick={() => setShowCookieDetails(!showCookieDetails)}
+                  className="w-full flex items-center justify-center text-gray-600 hover:text-gray-800 py-2 text-xs sm:text-sm transition-colors duration-200"
+                  type="button"
+                >
+                  <Eye className="w-4 h-4 mr-1" />
+                  {showCookieDetails ? "Hide" : "Show"} Cookie Details
+                </button>
+              </div>
+
+              {showCookieDetails && (
+                <div className="mt-4 p-3 sm:p-4 bg-green-50 rounded-xl border border-green-100 text-xs sm:text-sm text-gray-700">
+                  <h4 className="font-semibold mb-2 text-green-800">Cookie Information</h4>
+                  <ul className="space-y-1 text-xs">
+                    <li>
+                      • <strong>Essential:</strong> Session management, security, age verification
+                    </li>
+                    <li>
+                      • <strong>Analytics:</strong> Google Analytics, usage statistics, performance
+                    </li>
+                    <li>
+                      • <strong>Marketing:</strong> Ad personalization, retargeting, social media
+                    </li>
+                    <li>
+                      • <strong>Functional:</strong> Language preferences, user settings, themes
+                    </li>
+                  </ul>
+                  <p className="mt-2 text-xs text-gray-500">
+                    Cookies are stored securely and you can change these preferences anytime.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="px-4 sm:px-8 pb-4 sm:pb-6 text-center">
+            <p className="text-xs text-gray-500">
+              By continuing, you agree to our{" "}
+              <a href="/terms" className="text-green-600 hover:underline">
+                Terms of Service
+              </a>{" "}
+              and{" "}
+              <a href="/privacy" className="text-green-600 hover:underline">
+                Privacy Policy
+              </a>
+            </p>
           </div>
-        )}
-      </div>
-    </div>
+        </>
+      )}
+    </Modal>
   );
 }

--- a/src/components/AgeGate.tsx
+++ b/src/components/AgeGate.tsx
@@ -1,371 +1,180 @@
-'use client';
-import { useState, useEffect } from "react";
-import { Shield, Calendar, Cookie, Eye, Lock, Check, Leaf } from "lucide-react";
+"use client";
 
-type Step = 'age' | 'privacy' | 'complete';
+import type { ChangeEvent } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { CheckCircle2, ShieldCheck } from "lucide-react";
 
-interface CookiePreferences {
-  essential: boolean;
-  analytics: boolean;
-  marketing: boolean;
-  functional: boolean;
+export type AgeGateStateOption = {
+  slug: string;
+  name: string;
+  abbreviation: string;
+  tagline?: string;
+};
+
+interface AgeGateProps {
+  states?: AgeGateStateOption[];
+  initialStateSlug?: string | null;
 }
 
-type CookieType = keyof Omit<CookiePreferences, 'essential'>;
+const AGE_COOKIE_NAME = "ageVerify";
+const STATE_COOKIE_NAME = "preferredState";
+const STATE_STORAGE_KEY = "terptier:selectedState";
 
-interface ModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  children: React.ReactNode;
-}
+const setCookie = (name: string, value: string, maxAgeDays: number) => {
+  const expires = new Date();
+  expires.setDate(expires.getDate() + maxAgeDays);
+  document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/;SameSite=Lax`;
+};
 
-function Modal({ isOpen, onClose, children }: ModalProps) {
-  if (!isOpen) return null;
-
-  return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="bg-white/95 backdrop-blur-xl rounded-3xl shadow-2xl w-full max-w-lg mx-4 max-h-[95vh] overflow-y-auto border border-green-200/30">
-        {children}
-      </div>
-    </div>
-  );
-}
-
-export default function AgeGate() {
-  const [open, setOpen] = useState<boolean>(true);
-  const [step, setStep] = useState<Step>('age');
-  const [ageVerify, setAgeVerify] = useState<boolean>(false);
-  const [privacyAccepted, setPrivacyAccepted] = useState<boolean>(false);
-  const [cookiePreferences, setCookiePreferences] = useState<CookiePreferences>({
-    essential: true,
-    analytics: false,
-    marketing: false,
-    functional: false
-  });
-  const [showCookieDetails, setShowCookieDetails] = useState<boolean>(false);
-
-  // Cookie utility functions
-  const setCookie = (name: string, value: string, days: number): void => {
-    const expires = new Date();
-    expires.setTime(expires.getTime() + (days * 24 * 60 * 60 * 1000));
-    document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/;SameSite=Lax`;
-  };
-
-  const getCookie = (name: string): string | null => {
-    const nameEQ = name + "=";
-    const ca = document.cookie.split(';');
-    for (let i = 0; i < ca.length; i++) {
-      let c = ca[i];
-      while (c.charAt(0) === ' ') c = c.substring(1, c.length);
-      if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+export default function AgeGate({
+  states = [],
+  initialStateSlug = null,
+}: AgeGateProps) {
+  const hasStates = states.length > 0;
+  const initialSelection = useMemo(() => {
+    if (!hasStates) {
+      return "";
     }
-    return null;
-  };
+    if (!initialStateSlug) {
+      return "";
+    }
+    const normalized = initialStateSlug.toLowerCase();
+    return states.some((state) => state.slug === normalized) ? normalized : "";
+  }, [hasStates, initialStateSlug, states]);
 
-  const deleteCookie = (name: string): void => {
-    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-  };
+  const [is21Confirmed, setIs21Confirmed] = useState(false);
+  const [selectedState, setSelectedState] = useState(initialSelection);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [complete, setComplete] = useState(false);
 
-  // Check existing cookies on mount
-  useEffect(() => {
-    const ageVerify = getCookie('ageVerify');
-    const privacyConsent = getCookie('privacyConsent');
-    const cookiePrefs = getCookie('cookiePreferences');
+  const handleStateChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
+    setSelectedState(event.target.value);
+    if (error) {
+      setError(null);
+    }
+  }, [error]);
 
-    if (ageVerify && privacyConsent) {
-      setOpen(false);
+  const handleConfirm = async () => {
+    if (submitting) {
       return;
-    } else if (ageVerify) {
-      setAgeVerify(true);
-      setStep('privacy');
     }
 
-    if (cookiePrefs) {
+    if (!is21Confirmed) {
+      setError("You must confirm that you are 21 or older to continue.");
+      return;
+    }
+
+    if (hasStates && !selectedState) {
+      setError("Please select your state before continuing.");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    setCookie(AGE_COOKIE_NAME, "true", 30);
+
+    if (hasStates && selectedState) {
+      setCookie(STATE_COOKIE_NAME, selectedState, 365);
       try {
-        const prefs = JSON.parse(decodeURIComponent(cookiePrefs));
-        setCookiePreferences(prev => ({ ...prev, ...prefs }));
-      } catch (e) {
-        console.error('Error parsing cookie preferences:', e);
+        window.localStorage.setItem(STATE_STORAGE_KEY, selectedState);
+      } catch (storageError) {
+        console.warn("Unable to persist state selection", storageError);
       }
     }
-  }, []);
 
-  const handleAgeConfirm = (): void => {
-    setAgeVerify(true);
-    setStep('privacy');
-    
-    // Set age verification cookie (30 days)
-    setCookie('ageVerify', 'true', 30);
-    
-    // Track that user confirmed age
-    console.log('Age verified and stored in cookies');
-  };
+    setComplete(true);
 
-  const handlePrivacyAccept = (): void => {
-    setPrivacyAccepted(true);
-    setStep('complete');
-    
-    // Set privacy consent cookie (365 days)
-    setCookie('privacyConsent', 'true', 365);
-    
-    // Set cookie preferences
-    setCookie('cookiePreferences', encodeURIComponent(JSON.stringify(cookiePreferences)), 365);
-    
-    // Set individual cookie flags based on preferences
-    if (cookiePreferences.analytics) {
-      setCookie('analyticsEnabled', 'true', 365);
-    } else {
-      deleteCookie('analyticsEnabled');
-    }
-    
-    if (cookiePreferences.marketing) {
-      setCookie('marketingEnabled', 'true', 365);
-    } else {
-      deleteCookie('marketingEnabled');
-    }
-    
-    if (cookiePreferences.functional) {
-      setCookie('functionalEnabled', 'true', 365);
-    } else {
-      deleteCookie('functionalEnabled');
-    }
-    
-    console.log('Privacy preferences saved:', cookiePreferences);
-    
-    // Close modal and reload page after animation
-    setTimeout(() => {
-      setOpen(false);
+    window.setTimeout(() => {
       window.location.reload();
-    }, 2000);
-  };
-
-  const toggleCookiePreference = (type: CookieType): void => {
-    setCookiePreferences(prev => ({
-      ...prev,
-      [type]: !prev[type]
-    }));
-  };
-
-  const handleRejectAll = (): void => {
-    setCookiePreferences({
-      essential: true,
-      analytics: false,
-      marketing: false,
-      functional: false
-    });
-  };
-
-  const handleAcceptAll = (): void => {
-    setCookiePreferences({
-      essential: true,
-      analytics: true,
-      marketing: true,
-      functional: true
-    });
+    }, 800);
   };
 
   return (
-    <Modal isOpen={open} onClose={() => {}}>
-      {step === 'complete' ? (
-        <div className="p-6 sm:p-8 text-center">
-          <div className="w-12 h-12 sm:w-16 sm:h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-            <Check className="w-6 h-6 sm:w-8 sm:h-8 text-green-600" />
-          </div>
-          <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-2">Welcome!</h2>
-          <p className="text-gray-600 mb-4 text-sm sm:text-base">Thank you for verifying your age and setting your privacy preferences.</p>
-          <div className="flex items-center justify-center space-x-2 text-sm text-green-600">
-            <Leaf className="w-4 h-4" />
-            <span>Preferences saved securely</span>
-          </div>
-          <div className="mt-4">
-            <div className="h-2 bg-green-200 rounded-full overflow-hidden">
-              <div className="h-full bg-green-600 rounded-full animate-[loading_2s_ease-in-out]"></div>
-            </div>
-          </div>
-        </div>
-      ) : (
-        <>
-          {/* Header */}
-          <div className="bg-gradient-to-r from-green-600 to-emerald-600 p-4 sm:p-6 text-white">
-            <div className="flex items-center justify-center mb-3">
-              {step === 'age' ? (
-                <Shield className="w-6 h-6 sm:w-8 sm:h-8 mr-2 sm:mr-3" />
-              ) : (
-                <Lock className="w-6 h-6 sm:w-8 sm:h-8 mr-2 sm:mr-3" />
-              )}
-              <h1 className="text-lg sm:text-2xl font-bold">
-                {step === 'age' ? 'Age Verification' : 'Privacy & Cookies'}
-              </h1>
-            </div>
-            
-            {/* Progress Bar */}
-            <div className="w-full bg-white/20 rounded-full h-2">
-              <div 
-                className="bg-white h-2 rounded-full transition-all duration-500 ease-out"
-                style={{ width: step === 'age' ? '50%' : '100%' }}
-              />
-            </div>
-          </div>
-
-          {/* Age Verification Step */}
-          {step === 'age' && (
-            <div className="p-4 sm:p-8">
-              <div className="text-center mb-6 sm:mb-8">
-                <div className="w-16 h-16 sm:w-20 sm:h-20 bg-gradient-to-br from-green-100 to-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                  <Calendar className="w-8 h-8 sm:w-10 sm:h-10 text-green-600" />
-                </div>
-                <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-3">Age Verification Required</h2>
-                <p className="text-gray-600 text-sm sm:text-lg leading-relaxed px-2">
-                  To access this content, you must be <strong>21 years or older</strong>. 
-                  Please confirm your age to continue.
-                </p>
-              </div>
-              
-              <div className="space-y-3 sm:space-y-4">
-                <button
-                  onClick={handleAgeConfirm}
-                  className="w-full bg-gradient-to-r cursor-pointer from-green-600 to-emerald-600 hover:from-green-700 hover:to-emerald-700 text-white font-semibold py-3 sm:py-4 px-4 sm:px-6 rounded-xl transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg hover:shadow-xl text-sm sm:text-base"
-                >
-                  ✓ I'm 21 or older
-                </button>
-                
-                <button
-                  onClick={() => window.history.back()}
-                  className="w-full bg-gray-100 cursor-pointer hover:bg-gray-200 text-gray-700 font-medium py-3 sm:py-4 px-4 sm:px-6 rounded-xl transition-all duration-200 border border-gray-200 text-sm sm:text-base"
-                >
-                  I'm under 21
-                </button>
-              </div>
-              
-              <div className="mt-4 sm:mt-6 text-center">
-                <p className="text-xs text-gray-500">
-                  Your age verification will be stored for 30 days
-                </p>
-              </div>
-            </div>
-          )}
-
-          {/* Privacy & Cookies Step */}
-          {step === 'privacy' && (
-            <div className="p-4 sm:p-8">
-              <div className="text-center mb-4 sm:mb-6">
-                <div className="w-12 h-12 sm:w-16 sm:h-16 bg-gradient-to-br from-green-100 to-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                  <Cookie className="w-6 h-6 sm:w-8 sm:h-8 text-green-600" />
-                </div>
-                <h2 className="text-lg sm:text-xl font-bold text-gray-800 mb-2">Privacy & Cookie Preferences</h2>
-                <p className="text-gray-600 text-xs sm:text-sm">
-                  We respect your privacy. Choose your cookie preferences below.
-                </p>
-              </div>
-
-              <div className="space-y-3 sm:space-y-4 mb-4 sm:mb-6">
-                {/* Essential Cookies */}
-                <div className="flex items-center justify-between p-3 sm:p-4 bg-green-50 rounded-xl border border-green-100">
-                  <div className="flex-1 pr-3">
-                    <h3 className="font-semibold text-gray-800 text-sm sm:text-base">Essential Cookies</h3>
-                    <p className="text-xs sm:text-sm text-gray-600">Required for basic site functionality</p>
-                  </div>
-                  <div className="w-10 h-5 cursor-not-allowed sm:w-12 sm:h-6 bg-green-500 rounded-full flex items-center justify-end px-1">
-                    <div className="w-3 h-3 sm:w-4 sm:h-4 bg-white rounded-full"></div>
-                  </div>
-                </div>
-
-                {/* Analytics Cookies */}
-                <div className="flex items-center justify-between p-3 sm:p-4 bg-gray-50 rounded-xl border">
-                  <div className="flex-1 pr-3">
-                    <h3 className="font-semibold text-gray-800 text-sm sm:text-base">Analytics</h3>
-                    <p className="text-xs sm:text-sm text-gray-600">Help us improve our service</p>
-                  </div>
-                  <button
-                    onClick={() => toggleCookiePreference('analytics')}
-                    className={`w-10 h-5 cursor-pointer sm:w-12 sm:h-6 rounded-full flex items-center px-1 transition-all duration-200 ${
-                      cookiePreferences.analytics 
-                        ? 'bg-green-500 justify-end' 
-                        : 'bg-gray-300 justify-start'
-                    }`}
-                  >
-                    <div className="w-3 h-3 sm:w-4 sm:h-4 bg-white rounded-full"></div>
-                  </button>
-                </div>
-
-                {/* Marketing Cookies */}
-                <div className="flex items-center justify-between p-3 sm:p-4 bg-gray-50 rounded-xl border">
-                  <div className="flex-1 pr-3">
-                    <h3 className="font-semibold text-gray-800 text-sm sm:text-base">Marketing</h3>
-                    <p className="text-xs sm:text-sm text-gray-600">Personalized content and ads</p>
-                  </div>
-                  <button
-                    onClick={() => toggleCookiePreference('marketing')}
-                    className={`w-10 h-5 cursor-pointer sm:w-12 sm:h-6 rounded-full flex items-center px-1 transition-all duration-200 ${
-                      cookiePreferences.marketing 
-                        ? 'bg-green-500 justify-end' 
-                        : 'bg-gray-300 justify-start'
-                    }`}
-                  >
-                    <div className="w-3 h-3 sm:w-4 sm:h-4 bg-white rounded-full"></div>
-                  </button>
-                </div>
-              </div>
-
-              <div className="space-y-3">
-                <div className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-3">
-                  <button
-                    onClick={handleAcceptAll}
-                    className="flex-1 cursor-pointer bg-green-100 hover:bg-green-200 text-green-700 font-semibold py-3 px-4 rounded-xl transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg text-sm border border-green-200"
-                  >
-                    Accept All
-                  </button>
-                  <button
-                    onClick={handleRejectAll}
-                    className="flex-1 cursor-pointer bg-red-100 hover:bg-red-200 text-red-700 font-medium py-3 px-4 rounded-xl transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg text-sm border border-red-200"
-                  >
-                    Reject All
-                  </button>
-                </div>
-                
-                <button
-                  onClick={handlePrivacyAccept}
-                  className="w-full cursor-pointer bg-gradient-to-r from-emerald-600 to-green-600 hover:from-emerald-700 hover:to-green-700 text-white font-semibold py-3 px-4 sm:px-6 rounded-xl transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg text-sm"
-                >
-                  Save My Preferences
-                </button>
-                
-                <button
-                  onClick={() => setShowCookieDetails(!showCookieDetails)}
-                  className="w-full cursor-pointer flex items-center justify-center text-gray-600 hover:text-gray-800 py-2 text-xs sm:text-sm transition-colors duration-200"
-                >
-                  <Eye className="w-4 h-4 mr-1" />
-                  {showCookieDetails ? 'Hide' : 'Show'} Cookie Details
-                </button>
-              </div>
-
-              {showCookieDetails && (
-                <div className="mt-4 p-3 sm:p-4 bg-green-50 rounded-xl border border-green-100 text-xs sm:text-sm text-gray-700">
-                  <h4 className="font-semibold mb-2 text-green-800">Cookie Information</h4>
-                  <ul className="space-y-1 text-xs">
-                    <li>• <strong>Essential:</strong> Session management, security, age verification</li>
-                    <li>• <strong>Analytics:</strong> Google Analytics, usage statistics, performance</li>
-                    <li>• <strong>Marketing:</strong> Ad personalization, retargeting, social media</li>
-                    <li>• <strong>Functional:</strong> Language preferences, user settings, themes</li>
-                  </ul>
-                  <p className="mt-2 text-xs text-gray-500">
-                    Cookies are stored securely and you can change these preferences anytime.
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Footer */}
-          <div className="px-4 sm:px-8 pb-4 sm:pb-6 text-center">
-            <p className="text-xs text-gray-500">
-              By continuing, you agree to our{' '}
-              <a href="/terms" className="text-green-600 hover:underline">Terms of Service</a> and{' '}
-              <a href="/privacy" className="text-green-600 hover:underline">Privacy Policy</a>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 backdrop-blur-sm p-4">
+      <div className="w-full max-w-xl rounded-3xl bg-white/95 p-8 shadow-2xl">
+        {complete ? (
+          <div className="flex flex-col items-center text-center space-y-4">
+            <CheckCircle2 className="h-16 w-16 text-emerald-500" />
+            <h2 className="text-2xl font-semibold text-slate-900">Welcome to TerpTier</h2>
+            <p className="text-slate-600">
+              Thank you for verifying your age{hasStates ? " and selecting your state" : ""}. Loading your experience now.
             </p>
           </div>
-        </>
-      )}
-    </Modal>
+        ) : (
+          <div className="space-y-6">
+            <div className="flex items-center space-x-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100">
+                <ShieldCheck className="h-7 w-7 text-emerald-600" />
+              </div>
+              <div>
+                <h2 className="text-xl font-semibold text-slate-900">Before we continue</h2>
+                <p className="text-sm text-slate-600">
+                  Please verify that you are at least 21 years old{hasStates ? " and tell us where you're exploring from." : "."}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <label className="flex items-center space-x-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-emerald-300">
+                <input
+                  type="checkbox"
+                  checked={is21Confirmed}
+                  onChange={(event) => {
+                    setIs21Confirmed(event.target.checked);
+                    if (error) {
+                      setError(null);
+                    }
+                  }}
+                  className="h-5 w-5 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+                />
+                <span className="text-sm font-medium text-slate-800">
+                  I confirm that I am at least 21 years old.
+                </span>
+              </label>
+
+              {hasStates ? (
+                <div className="space-y-2">
+                  <label htmlFor="state-select" className="text-sm font-medium text-slate-700">
+                    Select your state
+                  </label>
+                  <select
+                    id="state-select"
+                    value={selectedState}
+                    onChange={handleStateChange}
+                    className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 shadow-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                  >
+                    <option value="" disabled>
+                      Choose a state
+                    </option>
+                    {states.map((state) => (
+                      <option key={state.slug} value={state.slug}>
+                        {state.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ) : null}
+            </div>
+
+            {error ? (
+              <p className="text-sm text-rose-600" role="alert">
+                {error}
+              </p>
+            ) : null}
+
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={submitting}
+              className="w-full rounded-full bg-gradient-to-r from-emerald-500 to-emerald-600 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:from-emerald-600 hover:to-emerald-700 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {submitting ? "Loading..." : "Enter TerpTier"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/components/HeroHome.tsx
+++ b/src/components/HeroHome.tsx
@@ -193,18 +193,6 @@ export default function HeroHome({ state }: HeroHomeProps) {
               </div>
             </motion.button>
           </Link>
-          <Link href="/login">
-            <motion.button
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
-              className="group cursor-pointer bg-white/5 backdrop-blur-sm text-white font-semibold px-8 py-4 rounded-full border border-white/20 hover:bg-white/15 transition-all duration-300"
-            >
-              <div className="flex items-center justify-center gap-2">
-                <LogIn size={20} />
-                <span>Log In</span>
-              </div>
-            </motion.button>
-          </Link>
           <Link href="/signup">
             <motion.button
               whileHover={{ scale: 1.05 }}

--- a/src/components/HeroHome.tsx
+++ b/src/components/HeroHome.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
-import { motion, useAnimation, useScroll, useTransform } from "framer-motion";
+import { useState, useEffect } from "react";
+import { motion } from "framer-motion";
 import { ChevronRight, Star, Users, TrendingUp, Cannabis } from "lucide-react";
 import Link from "next/link";
-import { DEFAULT_STATE_SLUG } from "@/lib/stateConstants";
 import Image from "next/image";
+import type { AgeGateStateOption } from "./AgeGate";
 
-export default function HeroHome() {
+type HeroHomeProps = {
+  state: Pick<AgeGateStateOption, "slug" | "name" | "tagline"> & {
+    abbreviation: string;
+  };
+};
+
+export default function HeroHome({ state }: HeroHomeProps) {
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
-  const { scrollY } = useScroll();
-  const controls = useAnimation();
 
   useEffect(() => {
     interface MouseEventWithClient extends MouseEvent {
@@ -74,6 +78,8 @@ export default function HeroHome() {
     },
   };
 
+  const stateTagline = state.tagline ?? `Discover ${state.name}'s finest producers`;
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-900 via-green-900 to-slate-900">
       <div className="absolute inset-0">
@@ -136,18 +142,6 @@ export default function HeroHome() {
         animate="visible"
         className="relative z-10 flex flex-col items-center justify-center min-h-[90vh] text-center px-4 pt-10 sm:pt-0"
       >
-        {/* <motion.div variants={itemVariants} className="mb-8">
-          <div className="relative">
-            <motion.div
-              className="absolute -inset-4 bg-gradient-to-r from-purple-600 via-pink-600 to-blue-600 rounded-full blur-xl opacity-30"
-              animate={{ scale: [1, 1.2, 1], opacity: [0.3, 0.6, 0.3] }}
-              transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
-            />
-            <div className="relative bg-white/10 backdrop-blur-sm rounded-full p-4 border border-white/20">
-              <Cannabis size={48} className="text-white" />
-            </div>
-          </div>
-        </motion.div> */}
         <Image
           src="/TerpTier.svg"
           alt="TerpTier logo"
@@ -159,24 +153,22 @@ export default function HeroHome() {
           variants={itemVariants}
           className="text-xl md:text-3xl font-light mb-4 text-white/90 max-w-3xl leading-relaxed"
         >
-          Find Colorado's{" "}
+          Discover {state.name}'s
           <span className="bg-gradient-to-r from-green-400 to-blue-400 bg-clip-text text-transparent font-semibold">
-            Top Tier Terps
+            {" "}Top Tier Terps
           </span>
         </motion.p>
         <motion.p
           variants={itemVariants}
           className="text-lg md:text-xl text-white/70 max-w-2xl mb-12 leading-relaxed"
         >
-          Rank & discover the best cannabis producers in Colorado. Join our
-          community of connoisseurs and share your favorites with fellow
-          enthusiasts.
+          {stateTagline}
         </motion.p>
         <motion.div
           variants={itemVariants}
           className="flex flex-col sm:flex-row gap-4 mb-12"
         >
-          <Link href={`/${DEFAULT_STATE_SLUG}/rankings`}>
+          <Link href={`/${state.slug}/rankings`}>
             <motion.button
               whileHover={{
                 scale: 1.05,
@@ -195,16 +187,16 @@ export default function HeroHome() {
               </div>
             </motion.button>
           </Link>
-          <Link href={`/${DEFAULT_STATE_SLUG}/drops`}>
+          <Link href={`/${state.slug}/drops`}>
             <motion.button
               whileHover={{
                 scale: 1.05,
                 boxShadow: "0 20px 40px rgba(0,0,0,0.3)",
               }}
               whileTap={{ scale: 0.95 }}
-              className="group relative cursor-pointer overflow-hidden bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-semibold px-8 py-4 rounded-full shadow-2xl transition-all duration-300"
+              className="group relative cursor-pointer overflow-hidden bg-white/10 text-white font-semibold px-8 py-4 rounded-full shadow-2xl transition-all duration-300"
             >
-              <div className="absolute inset-0 bg-gradient-to-r from-purple-500 to-indigo-500 translate-y-full group-hover:translate-y-0 transition-transform duration-300" />
+              <div className="absolute inset-0 bg-white/20 translate-y-full group-hover:translate-y-0 transition-transform duration-300" />
               <div className="relative flex items-center justify-center gap-2">
                 <span>Upcoming Drops</span>
                 <ChevronRight
@@ -214,70 +206,42 @@ export default function HeroHome() {
               </div>
             </motion.button>
           </Link>
-          <Link href="/about">
-            <motion.button
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
-              className="group relative cursor-pointer overflow-hidden bg-gradient-to-r from-purple-700 to-pink-600 backdrop-blur-sm text-white font-semibold px-8 py-4 rounded-full border border-white/20 hover:bg-white/20 transition-all duration-300"
-            >
-              <div className="absolute inset-0 bg-gradient-to-r from-purple-600 to-pink-500 translate-y-full group-hover:translate-y-0 transition-transform duration-300" />
-              <div className="relative flex items-center justify-center gap-2">
-                <span>About Us</span>
-                <ChevronRight
-                  size={20}
-                  className="group-hover:translate-x-1 transition-transform"
-                />
-              </div>
-            </motion.button>
-          </Link>
-          <Link href="/signup">
-            <motion.button
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
-              className="group cursor-pointer bg-white/10 backdrop-blur-sm text-white font-semibold px-8 py-4 rounded-full border border-white/20 hover:bg-white/20 transition-all duration-300"
-            >
-              <div className="flex items-center justify-center gap-2">
-                <Users size={20} />
-                <span>Sign Up</span>
-              </div>
-            </motion.button>
-          </Link>
         </motion.div>
-        {/* <motion.div
-          variants={itemVariants}
-          className="flex flex-wrap justify-center gap-8 text-center"
-        >
-          <div className="group">
-            <motion.div
-              className="text-3xl font-bold bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent"
-              animate={{ scale: [1, 1.05, 1] }}
-              transition={{ duration: 2, repeat: Infinity, delay: 0 }}
-            >
-              50+
-            </motion.div>
-            <div className="text-white/60 text-sm">Producers</div>
+      </motion.div>
+
+      <motion.div
+        className="relative z-10 grid gap-6 px-6 pb-16 sm:px-12 lg:px-24"
+        initial="hidden"
+        animate="visible"
+        variants={containerVariants}
+      >
+        <motion.div variants={itemVariants} className="rounded-3xl bg-white/10 backdrop-blur-sm border border-white/10 p-6 sm:p-8">
+          <div className="flex items-center gap-3 mb-4">
+            <Users className="h-6 w-6 text-emerald-300" />
+            <h3 className="text-lg font-semibold text-white">Real Community Voices</h3>
           </div>
-          <div className="group">
-            <motion.div
-              className="text-3xl font-bold bg-gradient-to-r from-green-400 to-blue-400 bg-clip-text text-transparent"
-              animate={{ scale: [1, 1.05, 1] }}
-              transition={{ duration: 2, repeat: Infinity, delay: 0.5 }}
-            >
-              30+
-            </motion.div>
-            <div className="text-white/60 text-sm">Reviews</div>
+          <p className="text-white/70 text-sm sm:text-base">
+            Join other connoisseurs from across {state.name} to rank your favorite producers and share your experiences.
+          </p>
+        </motion.div>
+        <motion.div variants={itemVariants} className="rounded-3xl bg-white/10 backdrop-blur-sm border border-white/10 p-6 sm:p-8">
+          <div className="flex items-center gap-3 mb-4">
+            <TrendingUp className="h-6 w-6 text-emerald-300" />
+            <h3 className="text-lg font-semibold text-white">Data-Driven Rankings</h3>
           </div>
-          <div className="group">
-            <motion.div
-              className="text-3xl font-bold bg-gradient-to-r from-yellow-400 to-orange-400 bg-clip-text text-transparent"
-              animate={{ scale: [1, 1.05, 1] }}
-              transition={{ duration: 2, repeat: Infinity, delay: 1 }}
-            >
-              20+
-            </motion.div>
-            <div className="text-white/60 text-sm">Members</div>
+          <p className="text-white/70 text-sm sm:text-base">
+            Explore evolving rankings tailored to {state.name}'s cannabis scene with insights from the community.
+          </p>
+        </motion.div>
+        <motion.div variants={itemVariants} className="rounded-3xl bg-white/10 backdrop-blur-sm border border-white/10 p-6 sm:p-8">
+          <div className="flex items-center gap-3 mb-4">
+            <Star className="h-6 w-6 text-emerald-300" />
+            <h3 className="text-lg font-semibold text-white">Curated Excellence</h3>
           </div>
-        </motion.div> */}
+          <p className="text-white/70 text-sm sm:text-base">
+            Stay on top of standout drops and must-try producers trusted by enthusiasts throughout {state.name}.
+          </p>
+        </motion.div>
       </motion.div>
     </div>
   );

--- a/src/components/HeroHome.tsx
+++ b/src/components/HeroHome.tsx
@@ -2,15 +2,13 @@
 
 import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
-import { ChevronRight, Star, Users, TrendingUp, Cannabis } from "lucide-react";
+import { ChevronRight, Star, Users, TrendingUp, Cannabis, LogIn } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
 import type { AgeGateStateOption } from "./AgeGate";
 
 type HeroHomeProps = {
-  state: Pick<AgeGateStateOption, "slug" | "name" | "tagline"> & {
-    abbreviation: string;
-  };
+  state: AgeGateStateOption;
 };
 
 export default function HeroHome({ state }: HeroHomeProps) {
@@ -22,9 +20,10 @@ export default function HeroHome({ state }: HeroHomeProps) {
       clientY: number;
     }
 
-    const handleMouseMove = (e: MouseEventWithClient): void => {
-      setMousePosition({ x: e.clientX, y: e.clientY });
+    const handleMouseMove = (event: MouseEventWithClient): void => {
+      setMousePosition({ x: event.clientX, y: event.clientY });
     };
+
     window.addEventListener("mousemove", handleMouseMove);
     return () => window.removeEventListener("mousemove", handleMouseMove);
   }, []);
@@ -78,7 +77,10 @@ export default function HeroHome({ state }: HeroHomeProps) {
     },
   };
 
-  const stateTagline = state.tagline ?? `Discover ${state.name}'s finest producers`;
+  const headlineStateName = state.name || state.abbreviation;
+  const supportingCopy = state.tagline
+    ? state.tagline
+    : `Rank & discover the best cannabis producers in ${headlineStateName}. Join our community of connoisseurs and share your favorites with fellow enthusiasts.`;
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-900 via-green-900 to-slate-900">
@@ -89,34 +91,30 @@ export default function HeroHome({ state }: HeroHomeProps) {
             background: `radial-gradient(circle at ${mousePosition.x}px ${mousePosition.y}px, rgba(255,0,150,0.1) 0%, rgba(0,255,255,0.1) 25%, rgba(255,255,0,0.1) 50%, rgba(255,0,255,0.1) 75%, transparent 100%)`,
           }}
         />
-        {particles.map((p, i) => (
+        {particles.map((particle, index) => (
           <motion.div
-            key={i}
+            key={index}
             className="absolute w-2 h-2 bg-gradient-to-r from-green-400 to-green-400 rounded-full opacity-30"
             style={{
-              left: p.left,
-              top: p.top,
+              left: particle.left,
+              top: particle.top,
             }}
             animate={{
               y: [0, -100, 0],
-              x: [0, p.x, 0],
+              x: [0, particle.x, 0],
               opacity: [0.3, 0.8, 0.3],
             }}
             transition={{
-              duration: p.duration,
+              duration: particle.duration,
               repeat: Infinity,
-              delay: p.delay,
+              delay: particle.delay,
             }}
           />
         ))}
         <div className="absolute inset-0 bg-gradient-to-r from-blue-800/20 via-green-800/20 to-blue-800/20 animate-pulse" />
       </div>
 
-      <motion.div
-        variants={floatingVariants}
-        animate="animate"
-        className="absolute top-20 left-20 text-purple-400 opacity-20"
-      >
+      <motion.div variants={floatingVariants} animate="animate" className="absolute top-20 left-20 text-purple-400 opacity-20">
         <Cannabis size={48} />
       </motion.div>
       <motion.div
@@ -142,105 +140,83 @@ export default function HeroHome({ state }: HeroHomeProps) {
         animate="visible"
         className="relative z-10 flex flex-col items-center justify-center min-h-[90vh] text-center px-4 pt-10 sm:pt-0"
       >
-        <Image
-          src="/TerpTier.svg"
-          alt="TerpTier logo"
-          className="my-8"
-          width={170}
-          height={50}
-        />
-        <motion.p
-          variants={itemVariants}
-          className="text-xl md:text-3xl font-light mb-4 text-white/90 max-w-3xl leading-relaxed"
-        >
-          Discover {state.name}'s
+        <Image src="/TerpTier.svg" alt="TerpTier logo" className="my-8" width={170} height={50} />
+        <motion.p variants={itemVariants} className="text-xl md:text-3xl font-light mb-4 text-white/90 max-w-3xl leading-relaxed">
+          Discover {headlineStateName}'s
           <span className="bg-gradient-to-r from-green-400 to-blue-400 bg-clip-text text-transparent font-semibold">
             {" "}Top Tier Terps
           </span>
         </motion.p>
-        <motion.p
-          variants={itemVariants}
-          className="text-lg md:text-xl text-white/70 max-w-2xl mb-12 leading-relaxed"
-        >
-          {stateTagline}
+        <motion.p variants={itemVariants} className="text-lg md:text-xl text-white/70 max-w-2xl mb-12 leading-relaxed">
+          {supportingCopy}
         </motion.p>
         <motion.div
           variants={itemVariants}
-          className="flex flex-col sm:flex-row gap-4 mb-12"
+          className="flex flex-col sm:flex-row flex-wrap justify-center gap-4 mb-12"
         >
           <Link href={`/${state.slug}/rankings`}>
             <motion.button
-              whileHover={{
-                scale: 1.05,
-                boxShadow: "0 20px 40px rgba(0,0,0,0.3)",
-              }}
+              whileHover={{ scale: 1.05, boxShadow: "0 20px 40px rgba(0,0,0,0.3)" }}
               whileTap={{ scale: 0.95 }}
               className="group relative cursor-pointer overflow-hidden bg-gradient-to-r from-green-600 to-green-700 text-white font-semibold px-8 py-4 rounded-full shadow-2xl transition-all duration-300"
             >
               <div className="absolute inset-0 bg-gradient-to-r from-green-500 to-green-600 translate-y-full group-hover:translate-y-0 transition-transform duration-300" />
               <div className="relative flex items-center justify-center gap-2">
                 <span>Explore Brands</span>
-                <ChevronRight
-                  size={20}
-                  className="group-hover:translate-x-1 transition-transform"
-                />
+                <ChevronRight size={20} className="group-hover:translate-x-1 transition-transform" />
               </div>
             </motion.button>
           </Link>
           <Link href={`/${state.slug}/drops`}>
             <motion.button
-              whileHover={{
-                scale: 1.05,
-                boxShadow: "0 20px 40px rgba(0,0,0,0.3)",
-              }}
+              whileHover={{ scale: 1.05, boxShadow: "0 20px 40px rgba(0,0,0,0.3)" }}
               whileTap={{ scale: 0.95 }}
-              className="group relative cursor-pointer overflow-hidden bg-white/10 text-white font-semibold px-8 py-4 rounded-full shadow-2xl transition-all duration-300"
+              className="group relative cursor-pointer overflow-hidden bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-semibold px-8 py-4 rounded-full shadow-2xl transition-all duration-300"
             >
-              <div className="absolute inset-0 bg-white/20 translate-y-full group-hover:translate-y-0 transition-transform duration-300" />
+              <div className="absolute inset-0 bg-gradient-to-r from-purple-500 to-indigo-500 translate-y-full group-hover:translate-y-0 transition-transform duration-300" />
               <div className="relative flex items-center justify-center gap-2">
                 <span>Upcoming Drops</span>
-                <ChevronRight
-                  size={20}
-                  className="group-hover:translate-x-1 transition-transform"
-                />
+                <ChevronRight size={20} className="group-hover:translate-x-1 transition-transform" />
               </div>
             </motion.button>
           </Link>
-        </motion.div>
-      </motion.div>
-
-      <motion.div
-        className="relative z-10 grid gap-6 px-6 pb-16 sm:px-12 lg:px-24"
-        initial="hidden"
-        animate="visible"
-        variants={containerVariants}
-      >
-        <motion.div variants={itemVariants} className="rounded-3xl bg-white/10 backdrop-blur-sm border border-white/10 p-6 sm:p-8">
-          <div className="flex items-center gap-3 mb-4">
-            <Users className="h-6 w-6 text-emerald-300" />
-            <h3 className="text-lg font-semibold text-white">Real Community Voices</h3>
-          </div>
-          <p className="text-white/70 text-sm sm:text-base">
-            Join other connoisseurs from across {state.name} to rank your favorite producers and share your experiences.
-          </p>
-        </motion.div>
-        <motion.div variants={itemVariants} className="rounded-3xl bg-white/10 backdrop-blur-sm border border-white/10 p-6 sm:p-8">
-          <div className="flex items-center gap-3 mb-4">
-            <TrendingUp className="h-6 w-6 text-emerald-300" />
-            <h3 className="text-lg font-semibold text-white">Data-Driven Rankings</h3>
-          </div>
-          <p className="text-white/70 text-sm sm:text-base">
-            Explore evolving rankings tailored to {state.name}'s cannabis scene with insights from the community.
-          </p>
-        </motion.div>
-        <motion.div variants={itemVariants} className="rounded-3xl bg-white/10 backdrop-blur-sm border border-white/10 p-6 sm:p-8">
-          <div className="flex items-center gap-3 mb-4">
-            <Star className="h-6 w-6 text-emerald-300" />
-            <h3 className="text-lg font-semibold text-white">Curated Excellence</h3>
-          </div>
-          <p className="text-white/70 text-sm sm:text-base">
-            Stay on top of standout drops and must-try producers trusted by enthusiasts throughout {state.name}.
-          </p>
+          <Link href="/about">
+            <motion.button
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+              className="group relative cursor-pointer overflow-hidden bg-gradient-to-r from-purple-700 to-pink-600 backdrop-blur-sm text-white font-semibold px-8 py-4 rounded-full border border-white/20 hover:bg-white/20 transition-all duration-300"
+            >
+              <div className="absolute inset-0 bg-gradient-to-r from-purple-600 to-pink-500 translate-y-full group-hover:translate-y-0 transition-transform duration-300" />
+              <div className="relative flex items-center justify-center gap-2">
+                <span>About Us</span>
+                <ChevronRight size={20} className="group-hover:translate-x-1 transition-transform" />
+              </div>
+            </motion.button>
+          </Link>
+          <Link href="/login">
+            <motion.button
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+              className="group cursor-pointer bg-white/5 backdrop-blur-sm text-white font-semibold px-8 py-4 rounded-full border border-white/20 hover:bg-white/15 transition-all duration-300"
+            >
+              <div className="flex items-center justify-center gap-2">
+                <LogIn size={20} />
+                <span>Log In</span>
+              </div>
+            </motion.button>
+          </Link>
+          <Link href="/signup">
+            <motion.button
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+              className="group cursor-pointer bg-white/10 backdrop-blur-sm text-white font-semibold px-8 py-4 rounded-full border border-white/20 hover:bg-white/20 transition-all duration-300"
+            >
+              <div className="flex items-center justify-center gap-2">
+                <Users size={20} />
+                <span>Sign Up</span>
+              </div>
+            </motion.button>
+          </Link>
         </motion.div>
       </motion.div>
     </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
 import Image from "next/image";
-import { LogIn, LogOut, UserPlus } from "lucide-react";
+import { LogIn, LogOut, UserPlus, ChevronDown, User, Shield, Calendar, Crown } from "lucide-react";
 import type { Session } from "@supabase/supabase-js";
 import DropOptInModal from "./DropOptInModal";
 import { DEFAULT_STATE, DEFAULT_STATE_SLUG } from "@/lib/stateConstants";
@@ -33,6 +33,7 @@ export default function Navbar() {
   const [showDropModal, setShowDropModal] = useState(false);
   const [states, setStates] = useState<StateOption[]>([DEFAULT_STATE]);
   const [selectedState, setSelectedState] = useState(DEFAULT_STATE_SLUG);
+  const [stateDropdownOpen, setStateDropdownOpen] = useState(false);
   const lastScrollY = useRef(0);
 
   const slugSet = useMemo(
@@ -82,9 +83,15 @@ export default function Navbar() {
     [selectedState],
   );
 
+  const selectedStateData = useMemo(
+    () => states.find(state => state.slug === selectedState) || states[0],
+    [states, selectedState]
+  );
+
   const handleStateChange = (newState: string) => {
     setSelectedState(newState);
     persistSelectedState(newState);
+    setStateDropdownOpen(false);
     router.push("/");
   };
 
@@ -238,6 +245,7 @@ export default function Navbar() {
       } else if (currentY > lastScrollY.current) {
         setShowBar(false);
         setMenuOpen(false);
+        setStateDropdownOpen(false);
       }
       lastScrollY.current = currentY;
     };
@@ -247,7 +255,21 @@ export default function Navbar() {
 
   useEffect(() => {
     setMenuOpen(false);
+    setStateDropdownOpen(false);
   }, [pathname]);
+
+  // Close dropdowns when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Element;
+      if (!target.closest('[data-dropdown]')) {
+        setStateDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, []);
 
   return (
     <>
@@ -255,10 +277,11 @@ export default function Navbar() {
         initial={{ y: 0 }}
         animate={{ y: showBar ? 0 : -80 }}
         transition={{ type: "tween", ease: "easeInOut", duration: 0.5 }}
-        className="bg-green-700 text-white shadow-md fixed top-0 left-0 right-0 z-50"
+        className="bg-gradient-to-r from-green-900/95 via-green-800/95 to-green-700/95 backdrop-blur-lg border-b border-white/10 text-white shadow-2xl fixed top-0 left-0 right-0 z-50"
       >
         <div className="container mx-auto px-4 flex items-center justify-between h-20">
-          <Link href="/" className="flex items-center hover:opacity-90">
+          {/* Logo */}
+          <Link href="/" className="flex items-center hover:opacity-90 transition-opacity duration-200">
             <Image
               src="/TerpTier.svg"
               alt="TerpTier logo"
@@ -267,107 +290,137 @@ export default function Navbar() {
               height={50}
             />
           </Link>
+
+          {/* Mobile Menu Button */}
           <div className="flex md:hidden mr-4">
             <button
               onClick={() => setMenuOpen(!menuOpen)}
-              className="relative w-8 h-8 focus:outline-none"
+              className="relative w-10 h-10 rounded-xl bg-white/10 backdrop-blur-sm border border-white/20 focus:outline-none hover:bg-white/20 transition-all duration-200 flex items-center justify-center"
               aria-label="Toggle menu"
             >
-              <span
-                className={`absolute left-1/2 w-6 h-0.5 bg-white transition-transform duration-300 ease-in-out ${
-                  menuOpen ? "rotate-45 top-2.5" : "top-2"
-                }`}
-                style={{ transformOrigin: "center" }}
-              />
-              <span
-                className={`absolute left-1/2 w-6 h-0.5 bg-white transition-transform duration-300 ease-in-out ${
-                  menuOpen ? "-rotate-45 top-2.5" : "top-5"
-                }`}
-                style={{ transformOrigin: "center" }}
-              />
+              <div className="relative w-6 h-6">
+                <span
+                  className={`absolute left-1/2 -translate-x-1/2 w-5 h-0.5 bg-white transition-transform duration-300 ease-in-out ${
+                    menuOpen ? "rotate-45 top-1/2 -translate-y-1/2" : "top-1.5"
+                  }`}
+                />
+                <span
+                  className={`absolute left-1/2 -translate-x-1/2 w-5 h-0.5 bg-white transition-all duration-300 ease-in-out ${
+                    menuOpen ? "opacity-0" : "top-1/2 -translate-y-1/2"
+                  }`}
+                />
+                <span
+                  className={`absolute left-1/2 -translate-x-1/2 w-5 h-0.5 bg-white transition-transform duration-300 ease-in-out ${
+                    menuOpen ? "-rotate-45 top-1/2 -translate-y-1/2" : "bottom-1.5"
+                  }`}
+                />
+              </div>
             </button>
           </div>
-          <div className="absolute right-8 top-1/2 -translate-y-1/2 md:hidden"></div>
+
+          {/* Desktop Menu */}
           <div className="hidden md:flex items-center space-x-6">
-            <div className="flex items-center space-x-2">
-              <label htmlFor="state-select" className="text-sm text-green-100">
-                State
-              </label>
-              <select
-                id="state-select"
-                className="bg-white text-green-700 text-sm rounded-full px-3 py-1 focus:outline-none focus:ring-2 focus:ring-green-300"
-                value={selectedState}
-                onChange={(event) => handleStateChange(event.target.value)}
+            {/* State Dropdown */}
+            <div className="relative" data-dropdown>
+              <button
+                onClick={() => setStateDropdownOpen(!stateDropdownOpen)}
+                className="flex items-center space-x-2 bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl px-4 py-2 hover:bg-white/20 transition-all duration-200 group"
               >
-                {states.map((state) => (
-                  <option key={state.slug} value={state.slug}>
-                    {state.name}
-                  </option>
-                ))}
-              </select>
+                <span className="text-sm font-medium">{selectedStateData?.name}</span>
+                <ChevronDown className={`w-4 h-4 transition-transform duration-200 ${stateDropdownOpen ? 'rotate-180' : ''}`} />
+              </button>
+              
+              <AnimatePresence>
+                {stateDropdownOpen && (
+                  <motion.div
+                    initial={{ opacity: 0, y: -10, scale: 0.95 }}
+                    animate={{ opacity: 1, y: 0, scale: 1 }}
+                    exit={{ opacity: 0, y: -10, scale: 0.95 }}
+                    transition={{ duration: 0.2, ease: "easeOut" }}
+                    className="absolute top-full mt-2 left-0 w-64 bg-white/95 backdrop-blur-xl border border-white/20 rounded-2xl shadow-2xl overflow-hidden z-50"
+                  >
+                    <div className="p-2">
+                      {states.map((state, index) => (
+                        <motion.button
+                          key={state.slug}
+                          initial={{ opacity: 0, x: -10 }}
+                          animate={{ opacity: 1, x: 0 }}
+                          transition={{ delay: index * 0.05 }}
+                          onClick={() => handleStateChange(state.slug)}
+                          className={`w-full text-left px-4 py-3 rounded-xl text-green-800 hover:bg-green-50/80 transition-all duration-200 ${
+                            selectedState === state.slug ? 'bg-green-100/80 font-semibold' : ''
+                          }`}
+                        >
+                          {state.name}
+                        </motion.button>
+                      ))}
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </div>
+
+            {/* Navigation Links */}
             <Link
               href={dropsPath}
-              className={`${
+              className={`flex items-center space-x-2 px-4 py-2 rounded-2xl text-sm font-medium transition-all duration-200 ${
                 pathname?.startsWith(dropsPath)
-                  ? "underline"
-                  : "hover:underline"
+                  ? "bg-white/20 backdrop-blur-sm"
+                  : "hover:bg-white/10 backdrop-blur-sm"
               }`}
             >
-              Drops
+              <Calendar className="w-4 h-4" />
+              <span>Drops</span>
             </Link>
             <Link
               href={rankingsPath}
-              className={`${
+              className={`flex items-center space-x-2 px-4 py-2 rounded-2xl text-sm font-medium transition-all duration-200 ${
                 pathname?.startsWith(rankingsPath)
-                  ? "underline"
-                  : "hover:underline"
+                  ? "bg-white/20 backdrop-blur-sm"
+                  : "hover:bg-white/10 backdrop-blur-sm"
               }`}
             >
-              Rankings
+              <Crown className="w-4 h-4" />
+              <span>Rankings</span>
             </Link>
 
             {profileUsername && (
               <Link
                 href={`/profile/${profileUsername}`}
-                className={`${
+                className={`flex items-center space-x-2 px-4 py-2 rounded-2xl text-sm font-medium transition-all duration-200 ${
                   pathname === `/profile/${profileUsername}`
-                    ? "underline"
-                    : "hover:underline"
+                    ? "bg-white/20 backdrop-blur-sm"
+                    : "hover:bg-white/10 backdrop-blur-sm"
                 }`}
               >
-                Profile
+                <User className="w-4 h-4" />
+                <span>Profile</span>
               </Link>
             )}
 
             {session && isAdmin && (
               <Link
                 href="/admin"
-                className={`${
-                  pathname === "/admin" ? "underline" : "hover:underline"
+                className={`flex items-center space-x-2 px-4 py-2 rounded-2xl text-sm font-medium transition-all duration-200 ${
+                  pathname === "/admin"
+                    ? "bg-white/20 backdrop-blur-sm"
+                    : "hover:bg-white/10 backdrop-blur-sm"
                 }`}
               >
-                Admin Panel
+                <Shield className="w-4 h-4" />
+                <span>Admin</span>
               </Link>
             )}
 
+            {/* Auth Buttons */}
             {!session ? (
-              <div className="flex items-center space-x-3">
-                <Link
-                  href="/login"
-                  className="flex items-center space-x-1 bg-white text-green-700 px-3 py-1 rounded-full hover:bg-green-50"
-                >
-                  <LogIn className="w-4 h-4" />
-                  <span>Log In</span>
-                </Link>
-                <Link
-                  href="/signup"
-                  className="flex items-center space-x-1 bg-white/10 text-white px-3 py-1 rounded-full border border-white/30 hover:bg-white/20"
-                >
-                  <UserPlus className="w-4 h-4" />
-                  <span>Sign Up</span>
-                </Link>
-              </div>
+              <Link
+                href="/login"
+                className="flex items-center space-x-2 bg-white/95 backdrop-blur-sm text-green-800 px-6 py-2.5 rounded-2xl font-medium hover:bg-white/100 hover:scale-105 transition-all duration-200 shadow-lg"
+              >
+                <LogIn className="w-4 h-4" />
+                <span>Log In</span>
+              </Link>
             ) : (
               <button
                 type="button"
@@ -376,7 +429,7 @@ export default function Navbar() {
                   setSession(null);
                   location.reload();
                 }}
-                className="flex items-center space-x-1 bg-red-600 hover:bg-red-700 px-3 py-1 rounded-full cursor-pointer"
+                className="flex items-center space-x-2 bg-red-500/90 backdrop-blur-sm hover:bg-red-600/90 px-6 py-2.5 rounded-2xl font-medium cursor-pointer hover:scale-105 transition-all duration-200 shadow-lg"
               >
                 <LogOut className="w-4 h-4 text-white" />
                 <span className="text-white">Sign Out</span>
@@ -384,6 +437,8 @@ export default function Navbar() {
             )}
           </div>
         </div>
+
+        {/* Mobile Menu */}
         <AnimatePresence>
           {menuOpen && (
             <motion.div
@@ -391,93 +446,102 @@ export default function Navbar() {
               initial={{ height: 0, opacity: 0 }}
               animate={{ height: "auto", opacity: 1 }}
               exit={{ height: 0, opacity: 0 }}
-              transition={{ duration: 0.45, ease: "easeInOut" }}
-              className="md:hidden overflow-hidden bg-green-800 border-t border-b border-green-900 pt-4 pb-6 space-y-4 flex flex-col items-center text-white"
+              transition={{ duration: 0.3, ease: "easeInOut" }}
+              className="md:hidden overflow-hidden bg-gradient-to-b from-green-800/95 to-green-900/95 backdrop-blur-lg border-t border-white/10"
             >
-              <div className="w-full px-6">
-                <label htmlFor="mobile-state-select" className="block text-xs uppercase tracking-wide text-green-200 mb-1">
-                  State
-                </label>
-                <select
-                  id="mobile-state-select"
-                  className="w-full bg-white text-green-700 text-sm rounded-full px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-300"
-                  value={selectedState}
-                  onChange={(event) => {
-                    handleStateChange(event.target.value);
-                    setMenuOpen(false);
-                  }}
-                >
-                  {states.map((state) => (
-                    <option key={state.slug} value={state.slug}>
-                      {state.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <Link
-                href={dropsPath}
-                onClick={() => setMenuOpen(false)}
-                className="w-full text-center py-1"
-              >
-                Drops
-              </Link>
-              <Link
-                href={rankingsPath}
-                onClick={() => setMenuOpen(false)}
-                className="w-full text-center py-1"
-              >
-                Rankings
-              </Link>
-              {profileUsername && (
-                <Link
-                  href={`/profile/${profileUsername}`}
-                  onClick={() => setMenuOpen(false)}
-                  className="w-full text-center py-1"
-                >
-                  Profile
-                </Link>
-              )}
-              {session && isAdmin && (
-                <Link
-                  href="/admin"
-                  onClick={() => setMenuOpen(false)}
-                  className="w-full text-center py-1"
-                >
-                  Admin Panel
-                </Link>
-              )}
-              {!session ? (
-                <div className="w-full flex flex-col items-center space-y-3">
-                  <Link
-                    href="/login"
-                    onClick={() => setMenuOpen(false)}
-                    className="w-full text-center py-2 bg-white text-green-700 rounded-full"
-                  >
-                    Log In
-                  </Link>
-                  <Link
-                    href="/signup"
-                    onClick={() => setMenuOpen(false)}
-                    className="w-full text-center py-2 bg-white/10 border border-white/30 rounded-full"
-                  >
-                    Sign Up
-                  </Link>
+              <div className="px-6 py-6 space-y-4">
+                {/* Mobile State Selector */}
+                <div className="space-y-2">
+                  <label className="block text-xs uppercase tracking-wide text-green-200 font-medium">
+                    State
+                  </label>
+                  <div className="relative">
+                    <select
+                      className="w-full bg-white/95 backdrop-blur-sm text-green-800 rounded-2xl px-4 py-3 pr-10 focus:outline-none focus:ring-2 focus:ring-white/50 appearance-none font-medium shadow-lg"
+                      value={selectedState}
+                      onChange={(event) => {
+                        handleStateChange(event.target.value);
+                        setMenuOpen(false);
+                      }}
+                    >
+                      {states.map((state) => (
+                        <option key={state.slug} value={state.slug}>
+                          {state.name}
+                        </option>
+                      ))}
+                    </select>
+                    <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-green-600 pointer-events-none" />
+                  </div>
                 </div>
-              ) : (
-                <button
-                  type="button"
-                  onClick={async () => {
-                    await supabase.auth.signOut();
-                    setSession(null);
-                    setMenuOpen(false);
-                    location.reload();
-                  }}
-                  className="text-center px-3 py-1 bg-red-600 hover:bg-red-700 rounded-full cursor-pointer text-white flex items-center justify-center space-x-1"
-                >
-                  <LogOut className="w-4 h-4" />
-                  <span>Sign Out</span>
-                </button>
-              )}
+
+                {/* Mobile Navigation Links */}
+                <div className="space-y-2 pt-4">
+                  <Link
+                    href={dropsPath}
+                    onClick={() => setMenuOpen(false)}
+                    className="flex items-center justify-center space-x-2 w-full py-3 bg-white/10 backdrop-blur-sm rounded-2xl hover:bg-white/20 transition-all duration-200 font-medium"
+                  >
+                    <Calendar className="w-4 h-4" />
+                    <span>Drops</span>
+                  </Link>
+                  <Link
+                    href={rankingsPath}
+                    onClick={() => setMenuOpen(false)}
+                    className="flex items-center justify-center space-x-2 w-full py-3 bg-white/10 backdrop-blur-sm rounded-2xl hover:bg-white/20 transition-all duration-200 font-medium"
+                  >
+                    <Crown className="w-4 h-4" />
+                    <span>Rankings</span>
+                  </Link>
+                  {profileUsername && (
+                    <Link
+                      href={`/profile/${profileUsername}`}
+                      onClick={() => setMenuOpen(false)}
+                      className="flex items-center justify-center space-x-2 w-full py-3 bg-white/10 backdrop-blur-sm rounded-2xl hover:bg-white/20 transition-all duration-200 font-medium"
+                    >
+                      <User className="w-4 h-4" />
+                      <span>Profile</span>
+                    </Link>
+                  )}
+                  {session && isAdmin && (
+                    <Link
+                      href="/admin"
+                      onClick={() => setMenuOpen(false)}
+                      className="flex items-center justify-center space-x-2 w-full py-3 bg-white/10 backdrop-blur-sm rounded-2xl hover:bg-white/20 transition-all duration-200 font-medium"
+                    >
+                      <Shield className="w-4 h-4" />
+                      <span>Admin Panel</span>
+                    </Link>
+                  )}
+                </div>
+
+                {/* Mobile Auth Buttons */}
+                <div className="pt-4 space-y-3">
+                  {!session ? (
+                    <Link
+                      href="/login"
+                      onClick={() => setMenuOpen(false)}
+                      className="flex items-center justify-center space-x-2 w-full py-3 bg-white/95 backdrop-blur-sm text-green-800 rounded-2xl font-medium shadow-lg"
+                    >
+                      <LogIn className="w-4 h-4" />
+                      <span>Log In</span>
+                    </Link>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        await supabase.auth.signOut();
+                        setSession(null);
+                        setMenuOpen(false);
+                        location.reload();
+                      }}
+                      className="flex items-center justify-center space-x-2 w-full py-3 bg-red-500/90 backdrop-blur-sm hover:bg-red-600/90 rounded-2xl font-medium cursor-pointer text-white shadow-lg"
+                    >
+                      <LogOut className="w-4 h-4" />
+                      <span>Sign Out</span>
+                    </button>
+                  )}
+                </div>
+              </div>
             </motion.div>
           )}
         </AnimatePresence>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
 import Image from "next/image";
-import { LogIn, LogOut } from "lucide-react";
+import { LogIn, LogOut, UserPlus } from "lucide-react";
 import type { Session } from "@supabase/supabase-js";
 import DropOptInModal from "./DropOptInModal";
 import { DEFAULT_STATE, DEFAULT_STATE_SLUG } from "@/lib/stateConstants";
@@ -85,7 +85,7 @@ export default function Navbar() {
   const handleStateChange = (newState: string) => {
     setSelectedState(newState);
     persistSelectedState(newState);
-    router.push(`/${newState}/rankings`);
+    router.push("/");
   };
 
   useEffect(() => {
@@ -352,13 +352,22 @@ export default function Navbar() {
             )}
 
             {!session ? (
-              <Link
-                href="/login"
-                className="flex items-center space-x-1 bg-white text-green-700 px-3 py-1 rounded-full hover:bg-green-50"
-              >
-                <LogIn className="w-4 h-4" />
-                <span>Log In / Sign Up</span>
-              </Link>
+              <div className="flex items-center space-x-3">
+                <Link
+                  href="/login"
+                  className="flex items-center space-x-1 bg-white text-green-700 px-3 py-1 rounded-full hover:bg-green-50"
+                >
+                  <LogIn className="w-4 h-4" />
+                  <span>Log In</span>
+                </Link>
+                <Link
+                  href="/signup"
+                  className="flex items-center space-x-1 bg-white/10 text-white px-3 py-1 rounded-full border border-white/30 hover:bg-white/20"
+                >
+                  <UserPlus className="w-4 h-4" />
+                  <span>Sign Up</span>
+                </Link>
+              </div>
             ) : (
               <button
                 type="button"
@@ -438,14 +447,22 @@ export default function Navbar() {
                 </Link>
               )}
               {!session ? (
-                <Link
-                  href="/login"
-                  onClick={() => setMenuOpen(false)}
-                  className="text-center py-1 px-3 bg-white text-green-700 rounded-full flex items-center justify-center space-x-1"
-                >
-                  <LogIn className="w-4 h-4" />
-                  <span>Log In / Sign Up</span>
-                </Link>
+                <div className="w-full flex flex-col items-center space-y-3">
+                  <Link
+                    href="/login"
+                    onClick={() => setMenuOpen(false)}
+                    className="w-full text-center py-2 bg-white text-green-700 rounded-full"
+                  >
+                    Log In
+                  </Link>
+                  <Link
+                    href="/signup"
+                    onClick={() => setMenuOpen(false)}
+                    className="w-full text-center py-2 bg-white/10 border border-white/30 rounded-full"
+                  >
+                    Sign Up
+                  </Link>
+                </div>
               ) : (
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- load supported states on the landing page and require a state selection alongside age verification
- persist the chosen state for the navbar and update home hero content to reflect the selected state
- add middleware to block unsupported state slugs before routing

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68ce1bb74d90832db054d0aaa3b69195