### PR TITLE
Guard producer admin routes by state

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,24 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## State-scoped producer admin APIs
+
+Administrative tooling for producers is scoped to a specific state. All server and
+client code that creates, lists, updates, or deletes producers **must** provide a
+state slug and will be rejected if the slug does not resolve to a known state.
+
+- `GET /api/producers` requires a `state=<slug>` query parameter. The results only
+  include producers from that state and each producer record includes the related
+  state slug for client-side validation.
+- `POST /api/admin/create-producer` accepts a state slug (legacy state codes are
+  still accepted when a slug is not available). The slug must map to an existing
+  state and, when both slug and code are supplied, they must refer to the same
+  record.
+- `PUT` and `DELETE /api/producers/[id]` require a `state=<slug>` query parameter.
+  The request will only succeed if the producer belongs to the provided slug.
+  Update requests silently ignore any attempt to move a producer between states.
+
+Future state-admin tooling should follow the same pattern: look up the state by
+slug first, validate that the requested producer belongs to that state, and avoid
+mutating `stateId` outside of dedicated migration flows.

--- a/src/app/api/producers/[id]/route.ts
+++ b/src/app/api/producers/[id]/route.ts
@@ -135,7 +135,13 @@ export async function PUT(
     const { id } = await params;
     const data = await request.json();
 
-    const { stateSlug: bodyStateSlug, stateCode, ...rest } = data;
+    const {
+      stateSlug: _bodyStateSlug,
+      stateCode: _bodyStateCode,
+      stateId: _bodyStateId,
+      state: _bodyState,
+      ...rest
+    } = data;
 
     const existingProducer = await ensureProducerInState(id, stateSlug);
     if (!existingProducer) {
@@ -145,30 +151,9 @@ export async function PUT(
       );
     }
 
-    let stateId = existingProducer.stateId;
-    const normalizedBodySlug =
-      typeof bodyStateSlug === "string" ? bodyStateSlug.toLowerCase() : undefined;
-    const normalizedBodyCode =
-      typeof stateCode === "string" ? stateCode.toUpperCase() : undefined;
-
-    if (normalizedBodySlug && normalizedBodySlug !== stateSlug) {
-      const state = await prisma.state.findUnique({ where: { slug: normalizedBodySlug } });
-      if (state) {
-        stateId = state.id;
-      }
-    } else if (normalizedBodyCode) {
-      const state = await prisma.state.findUnique({ where: { code: normalizedBodyCode } });
-      if (state) {
-        stateId = state.id;
-      }
-    }
-
     await prisma.producer.update({
       where: { id },
-      data: {
-        ...rest,
-        stateId,
-      },
+      data: rest,
     });
 
     return NextResponse.json({ success: true });


### PR DESCRIPTION
## Summary
- require a state slug when listing producers and scope prisma queries accordingly
- validate state input when creating producers and stop defaulting to Colorado
- enforce state-specific access for producer updates/deletes and document the guardrail

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68ce4a4a6650832da9f4efee6b436fe9