### PR TITLE
Ensure producer form uses state metadata context

### DIFF
--- a/src/app/[stateName]/admin/page.tsx
+++ b/src/app/[stateName]/admin/page.tsx
@@ -200,9 +200,7 @@ export default function StateAdminPage() {
         )}
         {stateMetadata && (
           <AddProducerForm
-            stateSlug={stateMetadata.slug}
-            stateCode={stateMetadata.abbreviation}
-            stateName={stateMetadata.name}
+            state={stateMetadata}
             onSaved={refreshProducers}
           />
         )}
@@ -312,9 +310,7 @@ export default function StateAdminPage() {
         <Modal isOpen={true} onClose={() => setEditing(null)}>
           <AddProducerForm
             producer={editing}
-            stateSlug={stateMetadata.slug}
-            stateCode={stateMetadata.abbreviation}
-            stateName={stateMetadata.name}
+            state={stateMetadata}
             onSaved={() => {
               setEditing(null);
               refreshProducers();

--- a/src/components/AddProducerForm.tsx
+++ b/src/components/AddProducerForm.tsx
@@ -3,23 +3,26 @@ import { useState } from "react";
 import ImageUpload from "./ImageUpload";
 import type { Producer } from "@prisma/client";
 
-type ProducerWithAttrs = Producer & { attributes: string[] };
+type ProducerWithAttrs = Producer & {
+  attributes: string[];
+  state?: { name?: string | null; slug?: string | null } | null;
+};
 import { ATTRIBUTE_OPTIONS } from "@/constants/attributes";
 
 type AddProducerFormProps = {
   producer?: ProducerWithAttrs;
   onSaved?: () => void;
-  stateSlug: string;
-  stateCode: string;
-  stateName?: string;
+  state: {
+    slug: string;
+    abbreviation: string;
+    name: string;
+  };
 };
 
 export default function AddProducerForm({
   producer,
   onSaved,
-  stateSlug,
-  stateCode,
-  stateName,
+  state,
 }: AddProducerFormProps) {
   const [name, setName] = useState(producer?.name ?? "");
   const [category, setCategory] = useState<"FLOWER" | "HASH">(
@@ -35,6 +38,8 @@ export default function AddProducerForm({
     producer?.profileImage ?? null,
   );
 
+  const displayStateName = producer?.state?.name ?? state.name;
+
   const save = async () => {
     const body = {
       name,
@@ -44,11 +49,11 @@ export default function AddProducerForm({
       slug,
       profileImage,
       attributes,
-      stateCode,
-      stateSlug,
+      stateCode: state.abbreviation,
+      stateSlug: state.slug,
     };
     if (producer) {
-      await fetch(`/api/producers/${producer.id}?state=${stateSlug}`, {
+      await fetch(`/api/producers/${producer.id}?state=${state.slug}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
@@ -75,11 +80,16 @@ export default function AddProducerForm({
 
   return (
     <div className="mb-6 space-y-2">
-      {stateName && (
-        <p className="text-sm text-gray-600">
-          Creating producers for {stateName}
-        </p>
-      )}
+      <div>
+        <label className="block text-xs font-semibold text-gray-500">
+          State
+        </label>
+        <input
+          value={displayStateName}
+          readOnly
+          className="border p-2 rounded w-full bg-gray-100 text-gray-700"
+        />
+      </div>
       <ImageUpload value={profileImage} onChange={setProfileImage} />
       <input
         placeholder="Producer name"


### PR DESCRIPTION
## Summary
- require state metadata when rendering the producer form and surface it in a read-only field for admins
- build create/update payloads with the provided state slug and code instead of hard-coded values
- pass the loaded state metadata into the add and edit producer forms on the admin page

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68ce4d9eba24832dbffa80fe4a64b3d0