### PR TITLE
Add state admin join table and role enum entry

### DIFF
--- a/prisma/migrations/20251015120000_add_state_admin/migration.sql
+++ b/prisma/migrations/20251015120000_add_state_admin/migration.sql
@@ -1,0 +1,14 @@
+-- AlterEnum
+ALTER TYPE "Role" ADD VALUE 'STATE_ADMIN';
+
+-- CreateTable
+CREATE TABLE "StateAdmin" (
+    "userId" TEXT NOT NULL,
+    "stateId" TEXT NOT NULL,
+
+    CONSTRAINT "StateAdmin_pkey" PRIMARY KEY ("userId", "stateId")
+);
+
+-- AddForeignKey
+ALTER TABLE "StateAdmin" ADD CONSTRAINT "StateAdmin_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "StateAdmin" ADD CONSTRAINT "StateAdmin_stateId_fkey" FOREIGN KEY ("stateId") REFERENCES "State"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ enum Role {
   USER
   ADMIN
   PRODUCER_ADMIN
+  STATE_ADMIN
 }
 
 enum Category {
@@ -29,6 +30,7 @@ model State {
   strains                Strain[]
   votes                  Vote[]
   producerRatingSnapshots ProducerRatingSnapshot[]
+  stateAdmins            StateAdmin[]
 }
 
 model User {
@@ -45,6 +47,7 @@ model User {
   votes             Vote[]
   comments          Comment[]
   producerAdmins    ProducerAdmin[]
+  stateAdmins       StateAdmin[]
   createdAt         DateTime        @default(now())
   updatedAt         DateTime        @updatedAt
   Producer          Producer[]
@@ -129,6 +132,15 @@ model ProducerAdmin {
   producerId String
 
   @@id([userId, producerId])
+}
+
+model StateAdmin {
+  user    User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId  String
+  state   State @relation(fields: [stateId], references: [id], onDelete: Cascade)
+  stateId String
+
+  @@id([userId, stateId])
 }
 
 model Strain {


### PR DESCRIPTION
## Summary
- add the STATE_ADMIN role value and connect state admin relations on the User and State models
- create a Prisma migration to introduce the StateAdmin join table with cascading foreign keys

## Testing
- npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68ce5c5f9448832d95dc0073e67958c6