### PR TITLE
Add state admin claims to custom access token

### DIFF
--- a/src/app/api/strains/route.ts
+++ b/src/app/api/strains/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prismadb";
-import { authorize } from "@/lib/authorize";
+import { authorize, JwtClaims } from "@/lib/authorize";
 import { Role } from "@prisma/client";
 
 interface CreateStrainBody {
@@ -14,12 +14,39 @@ interface CreateStrainBody {
 
 async function canManageProducer(
   producerId: string,
-  claims: any | null,
+  claims: JwtClaims | null,
   session: any,
 ) {
   if (claims?.role === "ADMIN") return true;
-  if (Array.isArray(claims?.producer_ids) && claims!.producer_ids.includes(producerId)) {
+  const producerClaims = claims?.producer_ids;
+  if (Array.isArray(producerClaims) && producerClaims.includes(producerId)) {
     return true;
+  }
+  const stateIdsClaim = claims?.state_ids;
+  const stateSlugsClaim = claims?.state_slugs;
+  if (
+    (Array.isArray(stateIdsClaim) && stateIdsClaim.length > 0) ||
+    (Array.isArray(stateSlugsClaim) && stateSlugsClaim.length > 0)
+  ) {
+    const producer = await prisma.producer.findUnique({
+      where: { id: producerId },
+      select: { stateId: true, state: { select: { slug: true } } },
+    });
+
+    if (producer) {
+      if (Array.isArray(stateIdsClaim) && stateIdsClaim.includes(producer.stateId)) {
+        return true;
+      }
+
+      const stateSlug = producer.state?.slug;
+      if (
+        stateSlug &&
+        Array.isArray(stateSlugsClaim) &&
+        stateSlugsClaim.includes(stateSlug)
+      ) {
+        return true;
+      }
+    }
   }
   if (session?.user?.email) {
     const user = await prisma.user.findUnique({

--- a/src/lib/authorize.ts
+++ b/src/lib/authorize.ts
@@ -13,6 +13,8 @@ if (!supabaseUrl || !supabaseKey) {
 export interface JwtClaims {
   role?: string;
   producer_ids?: string[];
+  state_ids?: string[];
+  state_slugs?: string[];
   [key: string]: any;
 }
 

--- a/supabase/edge-functions/custom_access_token_hook/index.ts
+++ b/supabase/edge-functions/custom_access_token_hook/index.ts
@@ -20,12 +20,28 @@ serve(async (req) => {
       .select("producerId")
       .eq("userId", user.id);
 
+    const { data: stateAdmins } = await supabase
+      .from("StateAdmin")
+      .select("stateId, state:State(slug)")
+      .eq("userId", user.id);
+
     const role = userRow?.role || "USER";
     const producer_ids = producers?.map((p) => p.producerId) || [];
+    const state_ids =
+      stateAdmins
+        ?.map((stateAdmin) => stateAdmin.stateId)
+        .filter((stateId): stateId is string => typeof stateId === "string") || [];
+    const state_slugs =
+      stateAdmins
+        ?.map((stateAdmin) => stateAdmin.state?.slug)
+        .filter((slug): slug is string => Boolean(slug)) || [];
 
-    return new Response(JSON.stringify({ role, producer_ids }), {
-      headers: { "Content-Type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({ role, producer_ids, state_ids, state_slugs }),
+      {
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   } catch (err) {
     console.error("token hook error", err);
     return new Response(JSON.stringify({}), { status: 200 });


### PR DESCRIPTION
## Summary
- include state admin assignments in the custom access token hook so JWT claims expose `state_ids` and `state_slugs`
- extend the shared `JwtClaims` type to surface the new state-level attributes
- allow producer management guards to authorize state admins when they oversee the producer's state

## Testing
- npm run lint *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5dfb0e0c832d9c9e999e216fcbba