### PR TITLE
Add admin access helper and enforce state scoped permissions

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,8 +9,16 @@ const nextConfig = {
   },
   images: {
     remotePatterns: [
-      new URL('https://elnwy0xndspvgnal.public.blob.vercel-storage.com/**'),
-      new URL('https://placehold.co/**'),
+      {
+        protocol: 'https',
+        hostname: 'elnwy0xndspvgnal.public.blob.vercel-storage.com',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'placehold.co',
+        pathname: '/**',
+      },
     ],
   },
 };

--- a/src/app/[stateName]/admin/[slug]/page.tsx
+++ b/src/app/[stateName]/admin/[slug]/page.tsx
@@ -24,7 +24,12 @@ export default async function ProducerAdminPage({
 
   const user = await prisma.user.findUnique({
     where: { email: session.user.email },
-    include: { producerAdmins: true },
+    include: {
+      producerAdmins: true,
+      stateAdmins: {
+        include: { state: { select: { id: true, slug: true } } },
+      },
+    },
   });
   if (!user) redirect("/login");
 
@@ -52,7 +57,11 @@ export default async function ProducerAdminPage({
 
   const isAdmin =
     user.role === "ADMIN" ||
-    user.producerAdmins.some((pa) => pa.producerId === producer.id);
+    user.producerAdmins.some((pa) => pa.producerId === producer.id) ||
+    user.stateAdmins.some((sa) => {
+      const slug = sa.state?.slug?.toLowerCase();
+      return sa.stateId === producer.stateId || slug === normalizedState;
+    });
   if (!isAdmin) redirect("/");
 
   return (

--- a/src/app/[stateName]/producer/[slug]/[strainSlug]/page.tsx
+++ b/src/app/[stateName]/producer/[slug]/[strainSlug]/page.tsx
@@ -164,7 +164,10 @@ export default async function StrainPage({ params }: StrainPageProps) {
               <div className="mb-6 lg:mb-0 lg:mr-8 flex-shrink-0">
                 <div className="relative w-32 h-32 lg:w-40 lg:h-40 rounded-3xl overflow-hidden bg-gradient-to-br from-green-100 to-emerald-100 ring-4 ring-green-200 shadow-xl">
                   <Image
-                    src={strain.imageUrl || "https://placehold.co/160x160/22c55e/ffffff?text=🌿"}
+                    src={
+                      strain.imageUrl ||
+                      "https://placehold.co/160x160/22c55e/ffffff.png?text=%F0%9F%8C%BF"
+                    }
                     alt={strain.name}
                     fill
                     className="object-cover"

--- a/src/app/api/strains/route.ts
+++ b/src/app/api/strains/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prismadb";
-import { authorize, JwtClaims } from "@/lib/authorize";
-import { Role } from "@prisma/client";
+import { authorize } from "@/lib/authorize";
+import {
+  evaluateAdminAccess,
+  getAdminScopedUserByEmail,
+} from "@/lib/adminAuthorization";
 
 interface CreateStrainBody {
   producerId: string;
@@ -10,57 +13,6 @@ interface CreateStrainBody {
   imageUrl?: string;
   releaseDate?: string | null;
   strainSlug?: string;
-}
-
-async function canManageProducer(
-  producerId: string,
-  claims: JwtClaims | null,
-  session: any,
-) {
-  if (claims?.role === "ADMIN") return true;
-  const producerClaims = claims?.producer_ids;
-  if (Array.isArray(producerClaims) && producerClaims.includes(producerId)) {
-    return true;
-  }
-  const stateIdsClaim = claims?.state_ids;
-  const stateSlugsClaim = claims?.state_slugs;
-  if (
-    (Array.isArray(stateIdsClaim) && stateIdsClaim.length > 0) ||
-    (Array.isArray(stateSlugsClaim) && stateSlugsClaim.length > 0)
-  ) {
-    const producer = await prisma.producer.findUnique({
-      where: { id: producerId },
-      select: { stateId: true, state: { select: { slug: true } } },
-    });
-
-    if (producer) {
-      if (Array.isArray(stateIdsClaim) && stateIdsClaim.includes(producer.stateId)) {
-        return true;
-      }
-
-      const stateSlug = producer.state?.slug;
-      if (
-        stateSlug &&
-        Array.isArray(stateSlugsClaim) &&
-        stateSlugsClaim.includes(stateSlug)
-      ) {
-        return true;
-      }
-    }
-  }
-  if (session?.user?.email) {
-    const user = await prisma.user.findUnique({
-      where: { email: session.user.email },
-      include: { producerAdmins: true },
-    });
-    if (user) {
-      return (
-        user.role === Role.ADMIN ||
-        user.producerAdmins.some((pa) => pa.producerId === producerId)
-      );
-    }
-  }
-  return false;
 }
 
 export async function GET(request: NextRequest) {
@@ -74,8 +26,27 @@ export async function GET(request: NextRequest) {
   if (!producerId) {
     return NextResponse.json({ success: false, error: "Missing producerId" }, { status: 400 });
   }
-  if (!(await canManageProducer(producerId, claims, session))) {
+
+  const email = session.user.email;
+  if (!email) {
     return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 });
+  }
+
+  const user = await getAdminScopedUserByEmail(email);
+  if (!user) {
+    return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 });
+  }
+
+  const access = await evaluateAdminAccess(
+    { user, claims },
+    { targetProducerId: producerId },
+  );
+
+  if (!access.allowed) {
+    const status = access.reason === "producer_not_found" ? 404 : 403;
+    const message =
+      access.reason === "producer_not_found" ? "Producer not found" : "Forbidden";
+    return NextResponse.json({ success: false, error: message }, { status });
   }
 
   try {
@@ -113,16 +84,31 @@ export async function POST(request: NextRequest) {
   if (!body.producerId || !body.name) {
     return NextResponse.json({ success: false, error: "Missing fields" }, { status: 400 });
   }
-  if (!(await canManageProducer(body.producerId, claims, session))) {
+
+  const email = session.user.email;
+  if (!email) {
     return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 });
   }
 
-  try {
-    const producer = await prisma.producer.findUnique({
-      where: { id: body.producerId },
-      select: { stateId: true },
-    });
+  const user = await getAdminScopedUserByEmail(email);
+  if (!user) {
+    return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 });
+  }
 
+  const access = await evaluateAdminAccess(
+    { user, claims },
+    { targetProducerId: body.producerId },
+  );
+
+  if (!access.allowed) {
+    const status = access.reason === "producer_not_found" ? 404 : 403;
+    const message =
+      access.reason === "producer_not_found" ? "Producer not found" : "Forbidden";
+    return NextResponse.json({ success: false, error: message }, { status });
+  }
+
+  try {
+    const producer = access.producer;
     if (!producer) {
       return NextResponse.json({ success: false, error: "Producer not found" }, { status: 404 });
     }

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -3,6 +3,13 @@ import { prisma } from "@/lib/prismadb";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 
+type StateAdminSummary = {
+  stateId: string;
+  slug: string;
+  name: string;
+  abbreviation: string;
+};
+
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
 
@@ -24,6 +31,23 @@ export async function GET() {
 
   const user = await prisma.user.findUnique({
     where: { email: session.user.email },
+    include: {
+      stateAdmins: {
+        include: {
+          state: {
+            select: {
+              id: true,
+              slug: true,
+              name: true,
+              code: true,
+            },
+          },
+        },
+      },
+      producerAdmins: {
+        select: { producerId: true },
+      },
+    },
   });
 
   if (!user) {
@@ -33,6 +57,19 @@ export async function GET() {
     );
   }
 
+  const stateAdminSummaries: StateAdminSummary[] = user.stateAdmins.map((stateAdmin) => ({
+    stateId: stateAdmin.stateId,
+    slug: stateAdmin.state.slug,
+    name: stateAdmin.state.name,
+    abbreviation: stateAdmin.state.code,
+  }));
+
+  const producerAdminIds = user.producerAdmins.map((producerAdmin) => producerAdmin.producerId);
+
+  const isGlobalAdmin = user.role === "ADMIN";
+  const isStateAdmin = stateAdminSummaries.length > 0;
+  const isProducerAdmin = producerAdminIds.length > 0;
+
   return NextResponse.json({
     success: true,
     id: user.id,
@@ -40,6 +77,11 @@ export async function GET() {
     username: user.username,
     profilePicUrl: user.profilePicUrl,
     notificationOptIn: user.notificationOptIn,
+    isGlobalAdmin,
+    isStateAdmin,
+    isProducerAdmin,
+    adminStates: stateAdminSummaries,
+    adminProducers: producerAdminIds,
   });
 }
 
@@ -53,10 +95,10 @@ export async function PATCH(request: Request) {
   } = await supabase.auth.getSession();
 
   if (!session?.user?.email) {
-      return NextResponse.json(
-        { success: false, error: "Not authenticated" },
-        { status: 401 },
-      );
+    return NextResponse.json(
+      { success: false, error: "Not authenticated" },
+      { status: 401 },
+    );
   }
 
   const { profilePicUrl, notificationOptIn } = await request.json();

--- a/src/components/StrainCard.tsx
+++ b/src/components/StrainCard.tsx
@@ -30,7 +30,7 @@ export default function StrainCard({
     >
       <div className="relative w-16 h-16 flex-shrink-0">
         <Image
-          src={strain.imageUrl || "https://placehold.co/64"}
+          src={strain.imageUrl || "https://placehold.co/64/png"}
           alt={strain.name}
           fill
           className="object-cover rounded"

--- a/src/lib/adminAuthorization.ts
+++ b/src/lib/adminAuthorization.ts
@@ -1,0 +1,122 @@
+import { prisma } from "@/lib/prismadb";
+import { Role } from "@prisma/client";
+import type { JwtClaims } from "@/lib/authorize";
+
+export type AdminScopedUser = Awaited<ReturnType<typeof getAdminScopedUserByEmail>>;
+
+type ProducerWithState = {
+  id: string;
+  stateId: string;
+  state: { slug: string };
+};
+
+export async function getAdminScopedUserByEmail(email: string) {
+  return prisma.user.findUnique({
+    where: { email },
+    include: {
+      producerAdmins: true,
+      stateAdmins: {
+        include: {
+          state: { select: { id: true, slug: true } },
+        },
+      },
+    },
+  });
+}
+
+interface AdminAccessTarget {
+  targetProducerId?: string | null;
+  targetStateId?: string | null;
+  targetStateSlug?: string | null;
+}
+
+interface AdminAccessContext {
+  claims: JwtClaims | null;
+  user: AdminScopedUser | null;
+}
+
+export type AdminAccessResult = {
+  allowed: boolean;
+  producer?: ProducerWithState | null;
+  stateId?: string | null;
+  stateSlug?: string | null;
+  reason?: "forbidden" | "producer_not_found" | "state_mismatch";
+};
+
+const arrayIncludes = (value: string | null | undefined, collection: unknown): boolean => {
+  if (!value) return false;
+  if (!Array.isArray(collection)) return false;
+  return collection.includes(value);
+};
+
+export async function evaluateAdminAccess(
+  context: AdminAccessContext,
+  target: AdminAccessTarget,
+): Promise<AdminAccessResult> {
+  const { claims, user } = context;
+  const { targetProducerId, targetStateId, targetStateSlug } = target;
+
+  let producer: ProducerWithState | null = null;
+  let stateId: string | null = null;
+  let stateSlug: string | null = null;
+
+  if (targetProducerId) {
+    producer = await prisma.producer.findUnique({
+      where: { id: targetProducerId },
+      select: { id: true, stateId: true, state: { select: { slug: true } } },
+    });
+
+    if (!producer) {
+      return { allowed: false, producer: null, stateId: null, stateSlug: null, reason: "producer_not_found" };
+    }
+
+    stateId = producer.stateId;
+    stateSlug = producer.state.slug;
+
+    if (targetStateId && targetStateId !== stateId) {
+      return { allowed: false, producer, stateId, stateSlug, reason: "state_mismatch" };
+    }
+
+    if (targetStateSlug && targetStateSlug !== stateSlug) {
+      return { allowed: false, producer, stateId, stateSlug, reason: "state_mismatch" };
+    }
+  } else {
+    stateId = targetStateId ?? null;
+    stateSlug = targetStateSlug ?? null;
+  }
+
+  const isGlobalAdmin =
+    claims?.role === "ADMIN" || user?.role === Role.ADMIN;
+  if (isGlobalAdmin) {
+    return { allowed: true, producer, stateId, stateSlug };
+  }
+
+  if (targetProducerId) {
+    if (arrayIncludes(targetProducerId, claims?.producer_ids)) {
+      return { allowed: true, producer, stateId, stateSlug };
+    }
+
+    if (user?.producerAdmins.some((pa) => pa.producerId === targetProducerId)) {
+      return { allowed: true, producer, stateId, stateSlug };
+    }
+  }
+
+  if (stateId || stateSlug) {
+    if (
+      arrayIncludes(stateId, claims?.state_ids) ||
+      arrayIncludes(stateSlug, claims?.state_slugs)
+    ) {
+      return { allowed: true, producer, stateId, stateSlug };
+    }
+
+    if (
+      user?.stateAdmins.some(
+        (sa) => sa.stateId === stateId || sa.state.slug === stateSlug,
+      )
+    ) {
+      return { allowed: true, producer, stateId, stateSlug };
+    }
+  }
+
+  return { allowed: false, producer, stateId, stateSlug, reason: "forbidden" };
+}

--- a/src/lib/adminAuthorization.ts
+++ b/src/lib/adminAuthorization.ts
@@ -11,8 +11,8 @@ type ProducerWithState = {
 };
 
 export async function getAdminScopedUserByEmail(email: string) {
-  return prisma.user.findUnique({
-    where: { email },
+  return prisma.user.findFirst({
+    where: { email: { equals: email, mode: "insensitive" } },
     include: {
       producerAdmins: true,
       stateAdmins: {

--- a/src/lib/authorize.ts
+++ b/src/lib/authorize.ts
@@ -18,7 +18,7 @@ export interface JwtClaims {
   [key: string]: any;
 }
 
-function decodeJwt(token: string): JwtClaims {
+export function decodeJwt(token: string): JwtClaims {
   try {
     const payload = token.split(".")[1];
     const decoded = Buffer.from(payload, "base64").toString();


### PR DESCRIPTION
## Summary
- add a shared admin authorization helper that understands global, producer, and state admins
- allow state admins to create and manage producers only within their assigned state
- enforce the same scoped authorization across strain endpoints using the helper

## Testing
- `npm run lint` *(fails: interactive Next.js ESLint configuration prompt blocks non-interactive run)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6103d98c832d8415ba460d7a0c9b