### PR TITLE
Respect existing roles and surface state admin assignments

### DIFF
--- a/src/app/[stateName]/admin/page.tsx
+++ b/src/app/[stateName]/admin/page.tsx
@@ -91,13 +91,18 @@ export default function StateAdminPage() {
           role?: string;
           isGlobalAdmin?: boolean;
           adminStates?: { slug: string }[];
+          stateAdminAssignments?: { stateId: string; stateSlug: string }[];
         };
 
-        const adminStateSlugs = Array.isArray(meData.adminStates)
-          ? meData.adminStates
-              .map((state) => state?.slug)
+        const adminStateSlugs = Array.isArray(meData.stateAdminAssignments)
+          ? meData.stateAdminAssignments
+              .map((assignment) => assignment?.stateSlug)
               .filter((slug): slug is string => Boolean(slug))
-          : [];
+          : Array.isArray(meData.adminStates)
+            ? meData.adminStates
+                .map((state) => state?.slug)
+                .filter((slug): slug is string => Boolean(slug))
+            : [];
 
         const isGlobalAdmin = Boolean(meData.isGlobalAdmin || meData.role === "ADMIN");
         const canManageState = isGlobalAdmin || adminStateSlugs.includes(stateSlug);

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -10,6 +10,11 @@ type StateAdminSummary = {
   abbreviation: string;
 };
 
+type StateAdminAssignment = {
+  stateId: string;
+  stateSlug: string;
+};
+
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
 
@@ -64,6 +69,13 @@ export async function GET() {
     abbreviation: stateAdmin.state.code,
   }));
 
+  const stateAdminAssignments: StateAdminAssignment[] = user.stateAdmins.map(
+    (stateAdmin) => ({
+      stateId: stateAdmin.stateId,
+      stateSlug: stateAdmin.state.slug,
+    }),
+  );
+
   const producerAdminIds = user.producerAdmins.map((producerAdmin) => producerAdmin.producerId);
 
   const isGlobalAdmin = user.role === "ADMIN";
@@ -81,6 +93,7 @@ export async function GET() {
     isStateAdmin,
     isProducerAdmin,
     adminStates: stateAdminSummaries,
+    stateAdminAssignments,
     adminProducers: producerAdminIds,
   });
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -29,6 +29,7 @@ type CurrentUserResponse = {
   profilePicUrl?: string | null;
   notificationOptIn: boolean;
   adminStates?: { slug: string }[];
+  stateAdminAssignments?: { stateId: string; stateSlug: string }[];
   adminProducers?: string[];
   isGlobalAdmin?: boolean;
   isStateAdmin?: boolean;
@@ -191,11 +192,15 @@ export default function Navbar() {
 
     setProfileUsername(data.username || data.id);
     setNotificationOptIn(data.notificationOptIn);
-    const adminSlugs = Array.isArray(data.adminStates)
-      ? data.adminStates
-          .map((state) => state?.slug)
+    const adminSlugs = Array.isArray(data.stateAdminAssignments)
+      ? data.stateAdminAssignments
+          .map((assignment) => assignment?.stateSlug)
           .filter((slug): slug is string => Boolean(slug))
-      : [];
+      : Array.isArray(data.adminStates)
+        ? data.adminStates
+            .map((state) => state?.slug)
+            .filter((slug): slug is string => Boolean(slug))
+        : [];
     const nextIsGlobalAdmin = data.isGlobalAdmin ?? data.role === "ADMIN";
     setIsGlobalAdmin(nextIsGlobalAdmin);
     setAdminStateSlugs(adminSlugs);


### PR DESCRIPTION
## Summary
- preserve existing user roles during profile updates while still forcing the configured global admin to remain an ADMIN
- default newly created users to the USER role and add explicit state-admin assignment data to the /api/users/me payload
- update Navbar and state admin page consumers to read the expanded response when determining available admin panels

## Testing
- not run (next lint prompts for interactive configuration in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce6db1d4cc832dafd0b4aea2adaa83