### PR TITLE
Adjust admin access handling

### DIFF
--- a/src/app/[stateName]/admin/[slug]/page.tsx
+++ b/src/app/[stateName]/admin/[slug]/page.tsx
@@ -55,13 +55,16 @@ export default async function ProducerAdminPage({
   });
   if (!producer) return notFound();
 
+  const managesProducerByState = user.stateAdmins.some((assignment) => {
+    const assignmentSlug = assignment.state?.slug?.toLowerCase();
+    return assignment.stateId === producer.stateId || assignmentSlug === normalizedState;
+  });
+
   const isAdmin =
     user.role === "ADMIN" ||
     user.producerAdmins.some((pa) => pa.producerId === producer.id) ||
-    user.stateAdmins.some((sa) => {
-      const slug = sa.state?.slug?.toLowerCase();
-      return sa.stateId === producer.stateId || slug === normalizedState;
-    });
+    managesProducerByState;
+
   if (!isAdmin) redirect("/");
 
   return (


### PR DESCRIPTION
## Summary
- tighten admin dashboard authorization by checking `/api/users/me` and redirecting users toward login or an assigned state when access is denied
- allow state administrators to reach producer management pages when they oversee the producer’s state
- surface admin navigation for assigned states by syncing the navbar selection and updating login redirects for state admins

## Testing
- not run (next lint prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68ce72448044832dbe762fa1323bdb8b