### PR TITLE
Update state-aware redirects and dropdown routing

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,11 +4,13 @@ import { NextResponse } from "next/server";
 const NON_STATE_SEGMENTS = new Set([
   "about",
   "admin",
+  "drops",
   "error",
   "faq",
   "feedback",
   "login",
   "not-found",
+  "rankings",
   "privacy",
   "profile",
   "signup",

--- a/src/app/drops/page.tsx
+++ b/src/app/drops/page.tsx
@@ -6,7 +6,7 @@ import { getAllStateMetadata } from "@/lib/states";
 const AGE_COOKIE_NAME = "ageVerify";
 const STATE_COOKIE_NAME = "preferredState";
 
-export default async function AdminLandingPage() {
+export default async function DropsLandingPage() {
   const cookieStore = await cookies();
   const is21 = cookieStore.get(AGE_COOKIE_NAME)?.value === "true";
   const preferredState = cookieStore.get(STATE_COOKIE_NAME)?.value ?? null;
@@ -23,7 +23,7 @@ export default async function AdminLandingPage() {
     preferredState !== null && serializableStates.some((state) => state.slug === preferredState);
 
   if (is21 && hasValidPreferredState) {
-    redirect(`/${preferredState}/admin`);
+    redirect(`/${preferredState}/drops`);
   }
 
   return (

--- a/src/app/rankings/page.tsx
+++ b/src/app/rankings/page.tsx
@@ -6,7 +6,7 @@ import { getAllStateMetadata } from "@/lib/states";
 const AGE_COOKIE_NAME = "ageVerify";
 const STATE_COOKIE_NAME = "preferredState";
 
-export default async function AdminLandingPage() {
+export default async function RankingsLandingPage() {
   const cookieStore = await cookies();
   const is21 = cookieStore.get(AGE_COOKIE_NAME)?.value === "true";
   const preferredState = cookieStore.get(STATE_COOKIE_NAME)?.value ?? null;
@@ -23,7 +23,7 @@ export default async function AdminLandingPage() {
     preferredState !== null && serializableStates.some((state) => state.slug === preferredState);
 
   if (is21 && hasValidPreferredState) {
-    redirect(`/${preferredState}/admin`);
+    redirect(`/${preferredState}/rankings`);
   }
 
   return (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -114,7 +114,38 @@ export default function Navbar() {
     setSelectedState(newState);
     persistSelectedState(newState);
     setStateDropdownOpen(false);
-    router.push("/");
+
+    const currentPath = pathname ?? "/";
+    const segments = currentPath.split("/").filter(Boolean);
+    const knownSections = new Set(["drops", "rankings", "admin"]);
+
+    if (segments.length === 0) {
+      router.push(`/${newState}`);
+      return;
+    }
+
+    const [first, ...rest] = segments;
+    const isStatePath = slugSet.has(first);
+
+    if (isStatePath) {
+      const [section, ...tail] = rest;
+      if (section && knownSections.has(section)) {
+        const suffix = tail.length ? `/${tail.join("/")}` : "";
+        router.push(`/${newState}/${section}${suffix}`);
+        return;
+      }
+
+      router.push(`/${newState}`);
+      return;
+    }
+
+    if (knownSections.has(first)) {
+      const suffix = rest.length ? `/${rest.join("/")}` : "";
+      router.push(`/${newState}/${first}${suffix}`);
+      return;
+    }
+
+    router.push(`/${newState}`);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add cookie-aware landing pages for `/drops`, `/rankings`, and `/admin` that redirect to the saved state or reopen the age gate
- ensure middleware excludes the new top-level routes from state validation
- update the navbar state selector to route directly to the corresponding state-specific drops, rankings, or admin page

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4a000898832dabbc431588db3df3