### PR TITLE
Add market field to Producer

### DIFF
--- a/prisma/migrations/20251110120000_add_market_to_producer/migration.sql
+++ b/prisma/migrations/20251110120000_add_market_to_producer/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "Market" AS ENUM ('WHITE', 'BLACK', 'BOTH');
+
+-- AlterTable
+ALTER TABLE "Producer" ADD COLUMN "market" "Market" NOT NULL DEFAULT 'BOTH';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,12 @@ enum Category {
   HASH
 }
 
+enum Market {
+  WHITE
+  BLACK
+  BOTH
+}
+
 model State {
   id    String @id @default(cuid())
   code  String @unique
@@ -58,6 +64,7 @@ model Producer {
   id                     String                   @id @default(cuid())
   name                   String
   category               Category
+  market                 Market                   @default(BOTH)
   state                  State                    @relation(fields: [stateId], references: [id])
   stateId                String
   logoUrl                String?

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Category, Role } from "@prisma/client";
+import { PrismaClient, Category, Market, Role } from "@prisma/client";
 import bcrypt from "bcrypt";
 
 const prisma = new PrismaClient({
@@ -73,7 +73,12 @@ async function main() {
         },
       },
       update: {},
-      create: { name, category: Category.FLOWER, stateId: colorado.id },
+      create: {
+        name,
+        category: Category.FLOWER,
+        stateId: colorado.id,
+        market: Market.BOTH,
+      },
     });
   }
 
@@ -101,7 +106,12 @@ async function main() {
         },
       },
       update: {},
-      create: { name, category: Category.HASH, stateId: colorado.id },
+      create: {
+        name,
+        category: Category.HASH,
+        stateId: colorado.id,
+        market: Market.BOTH,
+      },
     });
   }
 


### PR DESCRIPTION
## Summary
- add a Market enum and required field on Producer with a default of BOTH
- update database migration history to create the enum and column
- seed all producers with the new market value when running the Prisma seed script

## Testing
- npx prisma generate
- npm run db:seed *(fails: can't reach database server at `localhost:5432` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf56f14788832d88214452b85dc0eb