### PR TITLE
Add market selection to producer management

### DIFF
--- a/src/app/api/admin/create-producer/route.ts
+++ b/src/app/api/admin/create-producer/route.ts
@@ -38,6 +38,7 @@ export async function POST(request: Request) {
     attributes,
     slug,
     profileImage,
+    market,
     stateCode,
     stateSlug,
   } = await request.json();
@@ -52,6 +53,20 @@ export async function POST(request: Request) {
       { error: "State slug or code is required" },
       { status: 400 },
     );
+  }
+
+  const MARKET_VALUES = ["WHITE", "BOTH", "BLACK"] as const;
+  type MarketValue = (typeof MARKET_VALUES)[number];
+  const allowedMarkets = new Set<MarketValue>(MARKET_VALUES);
+  let normalizedMarket: MarketValue = "BOTH";
+  if (typeof market === "string") {
+    const candidate = market.toUpperCase();
+    if (!allowedMarkets.has(candidate as MarketValue)) {
+      return NextResponse.json({ error: "Invalid market" }, { status: 400 });
+    }
+    normalizedMarket = candidate as MarketValue;
+  } else if (market !== undefined && market !== null) {
+    return NextResponse.json({ error: "Invalid market" }, { status: 400 });
   }
 
   let state = null;
@@ -94,6 +109,7 @@ export async function POST(request: Request) {
       attributes,
       slug,
       profileImage,
+      market: normalizedMarket,
       createdById: user.id,
       stateId: state.id,
     },

--- a/src/components/AddProducerForm.tsx
+++ b/src/components/AddProducerForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 import ImageUpload from "./ImageUpload";
-import type { Producer } from "@prisma/client";
+import type { Market, Producer } from "@prisma/client";
 
 type ProducerWithAttrs = Producer & {
   attributes: string[];
@@ -37,6 +37,7 @@ export default function AddProducerForm({
   const [profileImage, setProfileImage] = useState<string | null>(
     producer?.profileImage ?? null,
   );
+  const [market, setMarket] = useState<Market>(producer?.market ?? "BOTH");
 
   const displayStateName = producer?.state?.name ?? state.name;
 
@@ -49,6 +50,7 @@ export default function AddProducerForm({
       slug,
       profileImage,
       attributes,
+      market,
       stateCode: state.abbreviation,
       stateSlug: state.slug,
     };
@@ -73,6 +75,7 @@ export default function AddProducerForm({
     setSlug("");
     setProfileImage(null);
     setAttributes([]);
+    setMarket("BOTH");
     // ideally revalidate or refresh the page:
     if (onSaved) onSaved();
     else window.location.reload();
@@ -134,6 +137,29 @@ export default function AddProducerForm({
           </label>
         ))}
       </div>
+      <fieldset className="space-y-1">
+        <legend className="block text-xs font-semibold text-gray-500">
+          Market
+        </legend>
+        <div className="flex gap-4">
+          {[
+            { label: "White", value: "WHITE" },
+            { label: "Both", value: "BOTH" },
+            { label: "Black", value: "BLACK" },
+          ].map((option) => (
+            <label key={option.value} className="flex items-center space-x-1 text-sm">
+              <input
+                type="radio"
+                name="market"
+                value={option.value}
+                checked={market === option.value}
+                onChange={() => setMarket(option.value as Market)}
+              />
+              <span>{option.label}</span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
       <select
         value={category}
         onChange={(e) => setCategory(e.target.value as any)}

--- a/src/components/AddProducerForm.tsx
+++ b/src/components/AddProducerForm.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useId, useState } from "react";
 import ImageUpload from "./ImageUpload";
 import type { Market, Producer } from "@prisma/client";
 
@@ -38,6 +38,7 @@ export default function AddProducerForm({
     producer?.profileImage ?? null,
   );
   const [market, setMarket] = useState<Market>(producer?.market ?? "BOTH");
+  const marketFieldName = useId();
 
   const displayStateName = producer?.state?.name ?? state.name;
 
@@ -146,18 +147,26 @@ export default function AddProducerForm({
             { label: "White", value: "WHITE" },
             { label: "Both", value: "BOTH" },
             { label: "Black", value: "BLACK" },
-          ].map((option) => (
-            <label key={option.value} className="flex items-center space-x-1 text-sm">
-              <input
-                type="radio"
-                name="market"
-                value={option.value}
-                checked={market === option.value}
-                onChange={() => setMarket(option.value as Market)}
-              />
-              <span>{option.label}</span>
-            </label>
-          ))}
+          ].map((option) => {
+            const inputId = `${marketFieldName}-${option.value.toLowerCase()}`;
+            return (
+              <label
+                key={option.value}
+                htmlFor={inputId}
+                className="flex items-center space-x-1 text-sm"
+              >
+                <input
+                  id={inputId}
+                  type="radio"
+                  name={marketFieldName}
+                  value={option.value}
+                  checked={market === option.value}
+                  onChange={() => setMarket(option.value as Market)}
+                />
+                <span>{option.label}</span>
+              </label>
+            );
+          })}
         </div>
       </fieldset>
       <select


### PR DESCRIPTION
## Summary
- add a market selector to the admin producer form and include the field in API payloads
- validate and persist the market value when creating producers in the admin route
- sanitize and allow updating the market field through the producer update API

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cf641244bc832d8e9db31163463c08