### PR TITLE
Theme category toggle and fix search icon

### DIFF
--- a/src/app/[stateName]/drops/page.tsx
+++ b/src/app/[stateName]/drops/page.tsx
@@ -45,9 +45,9 @@ export default async function DropsPage({
         ? "underground"
         : "";
 
-  const heroTitle = `Discover ${state.name}'s best ${
+  const heroTitle = `Coming Soon to the ${
     marketDescriptor ? `${marketDescriptor} ` : ""
-  }producers...`;
+  }Market`;
 
   const now = new Date();
   const mstParts = new Intl.DateTimeFormat("en-US", {

--- a/src/app/[stateName]/drops/page.tsx
+++ b/src/app/[stateName]/drops/page.tsx
@@ -38,6 +38,17 @@ export default async function DropsPage({
   const themeAttribute = market.toLowerCase();
   const theme = getMarketTheme(market).drops;
 
+  const marketDescriptor =
+    market === "WHITE"
+      ? "Recreational"
+      : market === "BLACK"
+        ? "Underground"
+        : "";
+
+  const heroTitle = marketDescriptor
+    ? `${state.name}'s Top ${marketDescriptor} Producers`
+    : `${state.name}'s Top Producers`;
+
   const now = new Date();
   const mstParts = new Intl.DateTimeFormat("en-US", {
     timeZone: "America/Denver",
@@ -183,13 +194,8 @@ export default async function DropsPage({
             <h1
               className={`text-4xl sm:text-5xl lg:text-6xl font-bold mb-3 sm:mb-4 py-2 sm:py-4 bg-clip-text text-transparent transition-colors duration-500 ${theme.hero.title}`}
             >
-              {state.name} Recent & Upcoming Drops
+              {heroTitle}
             </h1>
-            <p
-              className={`text-lg sm:text-xl mb-6 sm:mb-8 max-w-2xl mx-auto px-2 transition-colors duration-500 ${theme.hero.subtitle}`}
-            >
-              Discover premium strains from the last week and the upcoming week from top-tier producers.
-            </p>
             <div
               className={`flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 transition-colors duration-500 ${theme.hero.statText}`}
             >

--- a/src/app/[stateName]/drops/page.tsx
+++ b/src/app/[stateName]/drops/page.tsx
@@ -40,12 +40,16 @@ export default async function DropsPage({
 
   const marketDescriptor =
     market === "WHITE"
-      ? "recreational"
+      ? "Recreational"
       : market === "BLACK"
-        ? "underground"
-        : "";
+        ? "Underground"
+      : market === "BOTH"
+        ? ""
+        : null;
 
-  const heroTitle = `Coming Soon to the ${
+  const heroTitle = `New to the 
+  ${state.name ? state.name : ""}
+  ${ 
     marketDescriptor ? `${marketDescriptor} ` : ""
   }Market`;
 

--- a/src/app/[stateName]/drops/page.tsx
+++ b/src/app/[stateName]/drops/page.tsx
@@ -40,14 +40,14 @@ export default async function DropsPage({
 
   const marketDescriptor =
     market === "WHITE"
-      ? "Recreational"
+      ? "recreational"
       : market === "BLACK"
-        ? "Underground"
+        ? "underground"
         : "";
 
-  const heroTitle = marketDescriptor
-    ? `${state.name}'s Top ${marketDescriptor} Producers`
-    : `${state.name}'s Top Producers`;
+  const heroTitle = `Discover ${state.name}'s best ${
+    marketDescriptor ? `${marketDescriptor} ` : ""
+  }producers...`;
 
   const now = new Date();
   const mstParts = new Intl.DateTimeFormat("en-US", {

--- a/src/app/[stateName]/rankings/page.tsx
+++ b/src/app/[stateName]/rankings/page.tsx
@@ -102,14 +102,14 @@ export default async function RankingsPage({
 
   const marketDescriptor =
     selectedMarket === "WHITE"
-      ? "Recreational"
+      ? "recreational"
       : selectedMarket === "BLACK"
-        ? "Underground"
+        ? "underground"
         : "";
 
-  const heroTitle = marketDescriptor
-    ? `${state.name}'s Top ${marketDescriptor} Producers`
-    : `${state.name}'s Top Producers`;
+  const heroTitle = `Discover ${state.name}'s best ${
+    marketDescriptor ? `${marketDescriptor} ` : ""
+  }producers...`;
 
   return (
     <div

--- a/src/app/[stateName]/rankings/page.tsx
+++ b/src/app/[stateName]/rankings/page.tsx
@@ -100,6 +100,17 @@ export default async function RankingsPage({
   const totalVotes =
     [...flower, ...hash].reduce((acc, p) => acc + p.votes.length, 0) || 0;
 
+  const marketDescriptor =
+    selectedMarket === "WHITE"
+      ? "recreational"
+      : selectedMarket === "BLACK"
+        ? "underground"
+        : "";
+
+  const heroTitle = marketDescriptor
+    ? `Discover ${state.name}'s best ${marketDescriptor} producers...`
+    : `Discover ${state.name}'s best producers...`;
+
   return (
     <div
       data-market-theme={themeAttribute}
@@ -127,7 +138,7 @@ export default async function RankingsPage({
             <h1
               className={`text-5xl md:text-6xl font-bold mb-4 py-4 bg-clip-text text-transparent transition-colors duration-500 ${theme.hero.title}`}
             >
-              {state.name} Producer Rankings
+              {heroTitle}
             </h1>
 
             <p
@@ -187,6 +198,7 @@ export default async function RankingsPage({
           initialView={initialViewParam}
           cardAppearance={theme.producerCardAppearance}
           searchTheme={theme.search}
+          toggleTheme={theme.toggle}
         />
 
         <div className="text-center mt-8">

--- a/src/app/[stateName]/rankings/page.tsx
+++ b/src/app/[stateName]/rankings/page.tsx
@@ -102,14 +102,14 @@ export default async function RankingsPage({
 
   const marketDescriptor =
     selectedMarket === "WHITE"
-      ? "recreational"
+      ? "Recreational"
       : selectedMarket === "BLACK"
-        ? "underground"
+        ? "Underground"
         : "";
 
   const heroTitle = marketDescriptor
-    ? `Discover ${state.name}'s best ${marketDescriptor} producers...`
-    : `Discover ${state.name}'s best producers...`;
+    ? `${state.name}'s Top ${marketDescriptor} Producers`
+    : `${state.name}'s Top Producers`;
 
   return (
     <div
@@ -140,13 +140,6 @@ export default async function RankingsPage({
             >
               {heroTitle}
             </h1>
-
-            <p
-              className={`text-lg md:text-xl mb-8 max-w-2xl mx-auto transition-colors duration-500 ${theme.hero.subtitle}`}
-            >
-              {state.tagline ??
-                "Vote for your favorite producers and see who's in the lead! Scores are community-driven and update as votes roll in."}
-            </p>
 
             <div
               className={`flex flex-wrap items-center justify-center gap-6 transition-colors duration-500 ${theme.hero.statText}`}

--- a/src/app/[stateName]/rankings/page.tsx
+++ b/src/app/[stateName]/rankings/page.tsx
@@ -102,12 +102,12 @@ export default async function RankingsPage({
 
   const marketDescriptor =
     selectedMarket === "WHITE"
-      ? "recreational"
+      ? "Recreational"
       : selectedMarket === "BLACK"
-        ? "underground"
+        ? "Underground"
         : "";
 
-  const heroTitle = `${state.name}'s Best ${
+  const heroTitle = `${state.name}'s Top ${
     marketDescriptor ? `${marketDescriptor} ` : ""
   }Producers`;
 

--- a/src/app/[stateName]/rankings/page.tsx
+++ b/src/app/[stateName]/rankings/page.tsx
@@ -107,9 +107,9 @@ export default async function RankingsPage({
         ? "underground"
         : "";
 
-  const heroTitle = `Discover ${state.name}'s best ${
+  const heroTitle = `${state.name}'s Best ${
     marketDescriptor ? `${marketDescriptor} ` : ""
-  }producers...`;
+  }Producers`;
 
   return (
     <div

--- a/src/components/CategoryToggle.tsx
+++ b/src/components/CategoryToggle.tsx
@@ -17,12 +17,16 @@ const defaultTheme: ToggleTheme = {
     base:
       "absolute left-1.5 top-1.5 bottom-1.5 rounded-full transform transition-all duration-300 ease-out shadow-lg",
     flower: "bg-gradient-to-r from-green-600 to-green-700 translate-x-0 w-24",
-    hash: "bg-gradient-to-r from-green-500 to-green-600 translate-x-24 w-24",
+    hash: "bg-gradient-to-r from-green-500 to-green-600 translate-x-24 w-22",
   },
   label: {
     base: "font-semibold text-sm transition-all duration-300 ease-out",
     active: "text-white drop-shadow-sm",
     inactive: "text-gray-600 hover:text-gray-800",
+  },
+  labelWrapper: {
+    flower: "w-24",
+    hash: "w-22",
   },
   focusRing: "ring-green-400 ring-opacity-0 focus-within:ring-opacity-50",
 };
@@ -67,7 +71,9 @@ export default function CategoryToggle({
       />
 
       <div className="relative z-10 flex w-full">
-        <div className="flex items-center justify-center w-24 h-full">
+        <div
+          className={`flex items-center justify-center h-full ${theme.labelWrapper.flower}`}
+        >
           <span
             className={`${theme.label.base} ${
               isFlower ? theme.label.active : theme.label.inactive
@@ -76,7 +82,9 @@ export default function CategoryToggle({
             🌸 Flower
           </span>
         </div>
-        <div className="flex items-center justify-center w-24 h-full">
+        <div
+          className={`flex items-center justify-center h-full ${theme.labelWrapper.hash}`}
+        >
           <span
             className={`${theme.label.base} ${
               !isFlower ? theme.label.active : theme.label.inactive

--- a/src/components/CategoryToggle.tsx
+++ b/src/components/CategoryToggle.tsx
@@ -1,19 +1,45 @@
 // src/components/CategoryToggle.tsx
 "use client";
 
+import type { KeyboardEvent } from "react";
+import type { ToggleTheme } from "@/lib/market-theme";
+
 interface CategoryToggleProps {
   view: "flower" | "hash";
   setView: (view: "flower" | "hash") => void;
+  appearance?: ToggleTheme;
 }
 
-export default function CategoryToggle({ view, setView }: CategoryToggleProps) {
+const defaultTheme: ToggleTheme = {
+  container:
+    "bg-gradient-to-r from-gray-100 to-gray-200 shadow-inner border border-gray-400",
+  indicator: {
+    base:
+      "absolute left-1.5 top-1.5 bottom-1.5 rounded-full transform transition-all duration-300 ease-out shadow-lg",
+    flower: "bg-gradient-to-r from-green-600 to-green-700 translate-x-0 w-24",
+    hash: "bg-gradient-to-r from-amber-500 to-amber-600 translate-x-24 w-24",
+  },
+  label: {
+    base: "font-semibold text-sm transition-all duration-300 ease-out",
+    active: "text-white drop-shadow-sm",
+    inactive: "text-gray-600 hover:text-gray-800",
+  },
+  focusRing: "ring-green-400 ring-opacity-0 focus-within:ring-opacity-50",
+};
+
+export default function CategoryToggle({
+  view,
+  setView,
+  appearance,
+}: CategoryToggleProps) {
   const isFlower = view === "flower";
+  const theme = appearance ?? defaultTheme;
 
   const handleToggle = () => {
     setView(isFlower ? "hash" : "flower");
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       handleToggle();
@@ -22,7 +48,7 @@ export default function CategoryToggle({ view, setView }: CategoryToggleProps) {
 
   return (
     <div
-      className="relative flex items-center w-50 h-11 bg-gradient-to-r from-gray-100 to-gray-200 rounded-full p-1.5 cursor-pointer select-none shadow-inner border border-gray-400 hover:shadow-md transition-all duration-200"
+      className={`relative flex items-center w-50 h-11 rounded-full p-1.5 cursor-pointer select-none transition-all duration-200 focus:outline-none ${theme.container}`}
       onClick={handleToggle}
       onKeyDown={handleKeyDown}
       tabIndex={0}
@@ -30,44 +56,40 @@ export default function CategoryToggle({ view, setView }: CategoryToggleProps) {
       aria-checked={isFlower}
       aria-label="Toggle between flower and hash view"
     >
-      {/* Sliding indicator */}
       <div
-        className={`absolute left-1.5 top-1.5 bottom-1.5 bg-gradient-to-r from-green-600 to-green-700 rounded-full transform transition-all duration-300 ease-out shadow-lg ${
-          isFlower ? "translate-x-0 w-24" : "translate-x-24 w-22"
+        className={`${theme.indicator.base} ${
+          isFlower ? theme.indicator.flower : theme.indicator.hash
         }`}
         style={{
-          boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.2)"
+          boxShadow:
+            "0 2px 8px rgba(0, 0, 0, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.2)",
         }}
       />
-      
-      {/* Labels */}
+
       <div className="relative z-10 flex w-full">
         <div className="flex items-center justify-center w-24 h-full">
-          <span 
-            className={`font-semibold text-sm transition-all duration-300 ease-out ${
-              isFlower 
-                ? "text-white drop-shadow-sm" 
-                : "text-gray-600 hover:text-gray-800"
+          <span
+            className={`${theme.label.base} ${
+              isFlower ? theme.label.active : theme.label.inactive
             }`}
           >
             🌸 Flower
           </span>
         </div>
-        <div className="flex items-center justify-center w-22 h-full">
-          <span 
-            className={`font-semibold text-sm transition-all duration-300 ease-out ${
-              !isFlower 
-                ? "text-white drop-shadow-sm" 
-                : "text-gray-600 hover:text-gray-800"
+        <div className="flex items-center justify-center w-24 h-full">
+          <span
+            className={`${theme.label.base} ${
+              !isFlower ? theme.label.active : theme.label.inactive
             }`}
           >
             🍯 Hash
           </span>
         </div>
       </div>
-      
-      {/* Focus ring */}
-      <div className="absolute inset-0 rounded-full ring-2 ring-green-400 ring-opacity-0 transition-all duration-200 focus-within:ring-opacity-50" />
+
+      <div
+        className={`absolute inset-0 rounded-full ring-2 pointer-events-none transition-all duration-200 ${theme.focusRing}`}
+      />
     </div>
   );
 }

--- a/src/components/CategoryToggle.tsx
+++ b/src/components/CategoryToggle.tsx
@@ -17,7 +17,7 @@ const defaultTheme: ToggleTheme = {
     base:
       "absolute left-1.5 top-1.5 bottom-1.5 rounded-full transform transition-all duration-300 ease-out shadow-lg",
     flower: "bg-gradient-to-r from-green-600 to-green-700 translate-x-0 w-24",
-    hash: "bg-gradient-to-r from-amber-500 to-amber-600 translate-x-24 w-24",
+    hash: "bg-gradient-to-r from-green-500 to-green-600 translate-x-24 w-24",
   },
   label: {
     base: "font-semibold text-sm transition-all duration-300 ease-out",

--- a/src/components/ProducerCard.tsx
+++ b/src/components/ProducerCard.tsx
@@ -44,15 +44,21 @@ export default function ProducerCard({
     none: "bg-gray-200 text-gray-700",
   };
 
-  const glowClass =
-    useColors && color === "gold"
-      ? "glow-gold"
-      : useColors && color === "silver"
-      ? "glow-silver"
-      : useColors && color === "bronze"
-      ? "glow-bronze"
-      : "";
+  // Accent ring + outer shadow (no foreground overlays)
+  // Keeps the "highlight" outside the card so it won't look like a wash over the surface in gray/dark modes.
+  const topRank = useColors && rank <= 3;
+  const accentRing =
+    color === "gold"
+      ? "ring-yellow-400/40 shadow-[0_0_24px_rgba(250,204,21,0.25)]"
+      : color === "silver"
+      ? "ring-gray-300/40 shadow-[0_0_24px_rgba(209,213,219,0.22)]"
+      : color === "bronze"
+      ? "ring-orange-400/40 shadow-[0_0_24px_rgba(251,146,60,0.22)]"
+      : color === "green"
+      ? "ring-emerald-400/30 shadow-[0_0_24px_rgba(16,185,129,0.20)]"
+      : "ring-transparent shadow-none";
 
+  // Appearance palettes
   const appearanceStyles: Record<
     "light" | "gray" | "dark",
     {
@@ -64,6 +70,7 @@ export default function ProducerCard({
       commentIcon: string;
       attributeTag: string;
       attributeIcon: string;
+      baseRing: string; // subtle base ring so borders still feel crisp
     }
   > = {
     light: {
@@ -75,6 +82,7 @@ export default function ProducerCard({
       commentIcon: "text-green-600",
       attributeTag: "bg-green-200/30 text-green-700",
       attributeIcon: "text-green-400",
+      baseRing: "ring-0", // no extra ring in pure light
     },
     gray: {
       container:
@@ -87,6 +95,7 @@ export default function ProducerCard({
       commentIcon: "text-green-600",
       attributeTag: "bg-green-200/30 text-green-700",
       attributeIcon: "text-green-500",
+      baseRing: "ring-1 ring-black/5", // subtle edge to avoid the washed look
     },
     dark: {
       container: "bg-green-950/60 border border-green-800",
@@ -95,23 +104,37 @@ export default function ProducerCard({
       text: "text-green-50",
       comment: "text-green-200",
       commentIcon: "text-green-300",
-      attributeTag: "bg-green-200/30 text-green-200",
-      attributeIcon: "text-green-200",
+      attributeTag: "bg-emerald-400/10 text-emerald-100",
+      attributeIcon: "text-emerald-200",
+      baseRing: "ring-1 ring-white/5", // crisp edge in dark
     },
   };
 
   const activeAppearance = appearanceStyles[appearance];
-  const containerClass =
+  const containerBase =
     isTopTen === false ? activeAppearance.secondary : activeAppearance.container;
 
   const link = `/${stateSlug}/producer/${producer.slug ?? producer.id}`;
 
-  const badgeClasses = `flex items-center justify-center ${colorClasses[useColors ? color : "none"]} rounded-full w-10 h-10 font-bold`;
+  const badgeClasses = `flex items-center justify-center ${
+    colorClasses[useColors ? color : "none"]
+  } rounded-full w-10 h-10 font-bold`;
 
   return (
     <Link
       href={link}
-      className={`${containerClass} ${activeAppearance.hover} ${glowClass} ${activeAppearance.text} p-4 rounded shadow flex items-center space-x-4 transition-colors duration-300`}
+      className={[
+        // layout + stacking
+        "relative isolate overflow-hidden",
+        // base appearance
+        containerBase,
+        activeAppearance.hover,
+        activeAppearance.text,
+        // spacing
+        "p-4 rounded shadow flex items-center space-x-4 transition-colors duration-300",
+        // replace previous overlay glow with ring + outer shadow
+        topRank ? `ring-2 ${accentRing}` : activeAppearance.baseRing,
+      ].join(" ")}
     >
       {showRank && (
         <div className={badgeClasses}>
@@ -121,6 +144,7 @@ export default function ProducerCard({
           )}
         </div>
       )}
+
       {producer.profileImage || producer.logoUrl ? (
         <img
           src={producer.profileImage || producer.logoUrl!}
@@ -128,6 +152,7 @@ export default function ProducerCard({
           className="h-10 w-10 rounded-full object-cover"
         />
       ) : null}
+
       <div className="flex-1">
         <h2 className="text-lg font-semibold">{producer.name}</h2>
         <VoteButton
@@ -139,8 +164,9 @@ export default function ProducerCard({
           navigateOnClick
           linkSlug={producer.slug ?? producer.id}
         />
+
         {producer.attributes && producer.attributes.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-2">
+          <div className="flex flex-wrap w-[80%] gap-1 mt-2">
             {producer.attributes.map((a) => {
               const opt = ATTRIBUTE_OPTIONS[producer.category].find(
                 (o) => o.key === a
@@ -153,6 +179,7 @@ export default function ProducerCard({
                     <span className={activeAppearance.attributeIcon}>
                       {opt?.icon}
                     </span>
+                    {/* Optionally show label if desired: <span>{opt?.label ?? a}</span> */}
                   </span>
                 </Tooltip>
               );
@@ -160,6 +187,7 @@ export default function ProducerCard({
           </div>
         )}
       </div>
+
       <div className={`flex items-center text-sm ${activeAppearance.comment}`}>
         <MessageCircle
           className={`w-4 h-4 mr-1 ${activeAppearance.commentIcon}`}

--- a/src/components/ProducerList.tsx
+++ b/src/components/ProducerList.tsx
@@ -7,7 +7,7 @@ import SearchBar from "./SearchBar";
 import ProducerCard from "./ProducerCard";
 import CategoryToggle from "./CategoryToggle";
 import type { Producer, Vote } from "@prisma/client";
-import type { SearchTheme } from "@/lib/market-theme";
+import type { SearchTheme, ToggleTheme } from "@/lib/market-theme";
 
 // merge the generated Prisma Producer with its votes
 export type ProducerWithVotes = Producer & {
@@ -27,6 +27,7 @@ interface Props {
   useColors?: boolean;
   cardAppearance?: "light" | "gray" | "dark";
   searchTheme?: SearchTheme;
+  toggleTheme?: ToggleTheme;
 }
 
 export default function ProducerList({
@@ -36,6 +37,7 @@ export default function ProducerList({
   useColors = true,
   cardAppearance = "light",
   searchTheme,
+  toggleTheme,
 }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -108,7 +110,11 @@ export default function ProducerList({
   return (
     <>
       <div className="flex justify-center mb-4">
-        <CategoryToggle view={view} setView={updateView} />
+        <CategoryToggle
+          view={view}
+          setView={updateView}
+          appearance={toggleTheme}
+        />
       </div>
       <SearchBar
         onSearch={setSearchTerm}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -68,25 +68,25 @@ export default function SearchBar({
     <div className="mb-6 flex flex-col items-center">
       <div className="relative w-5/6 md:w-2/3 max-w-md">
         {/* Search icon */}
-        <div
-          className={`absolute left-4 top-1/2 -translate-y-1/2 transform ${theme.icon}`}
+        <span
+          className="absolute left-4 top-1/2 -translate-y-1/2 transform pointer-events-none"
+          aria-hidden="true"
         >
           <svg
-            width="20"
-            height="20"
-            viewBox="0 0 24 24" 
-            fill="none" 
+            className={`w-5 h-5 ${theme.icon}`}
+            viewBox="0 0 24 24"
+            fill="none"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <path 
-              d="M21 21L16.514 16.506M19 10.5C19 15.194 15.194 19 10.5 19S2 15.194 2 10.5 5.806 2 10.5 2 19 5.806 19 10.5Z" 
-              stroke="currentColor" 
-              strokeWidth="2" 
-              strokeLinecap="round" 
+            <path
+              d="M21 21L16.514 16.506M19 10.5C19 15.194 15.194 19 10.5 19S2 15.194 2 10.5 5.806 2 10.5 2 19 5.806 19 10.5Z"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
               strokeLinejoin="round"
             />
           </svg>
-        </div>
+        </span>
 
         {/* Input field */}
         <input

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
+import { Search } from "lucide-react";
 import type { SearchTheme } from "@/lib/market-theme";
 import AttributesFilter from "./AttributesFilter";
 
@@ -72,20 +73,7 @@ export default function SearchBar({
           className="absolute left-4 top-1/2 -translate-y-1/2 transform pointer-events-none"
           aria-hidden="true"
         >
-          <svg
-            className={`w-5 h-5 ${theme.icon}`}
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M21 21L16.514 16.506M19 10.5C19 15.194 15.194 19 10.5 19S2 15.194 2 10.5 5.806 2 10.5 2 19 5.806 19 10.5Z"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          <Search className={`w-5 h-5 ${theme.icon}`} strokeWidth={2} />
         </span>
 
         {/* Input field */}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -4,7 +4,7 @@ import type { SearchTheme } from "@/lib/market-theme";
 import AttributesFilter from "./AttributesFilter";
 
 const defaultTheme: SearchTheme = {
-  icon: "text-gray-400",
+  searchIcon: "text-gray-400", // applied below
   input:
     "bg-gradient-to-r from-gray-50 to-gray-100 text-gray-700 placeholder-gray-400 border-gray-300 hover:border-gray-400",
   inputFocus: "border-green-400 shadow-md bg-white",
@@ -12,7 +12,7 @@ const defaultTheme: SearchTheme = {
   filterButtonActive: "text-green-600",
   clearButton: "text-gray-400 hover:text-gray-600",
   focusRing: "ring-green-300",
-  panel: "bg-white shadow border border-gray-200", // border handled by rounded container
+  panel: "bg-white shadow border border-gray-200",
   attributeTag: "bg-gray-100 text-gray-700",
   attributeTagSelected: "bg-emerald-100 text-emerald-800",
   attributeCheckbox: "text-green-600",
@@ -68,24 +68,26 @@ export default function SearchBar({
     <div className="mb-6 flex flex-col items-center">
       <div className="relative w-5/6 md:w-2/3 max-w-md">
         {/* Search icon */}
-        <span
-          className={`absolute left-4 top-1/2 -translate-y-1/2 transform pointer-events-none flex items-center justify-center ${theme.icon}`}
+        <div
+          className={`absolute left-4 top-1/2 -translate-y-1/2 transform pointer-events-none z-10 ${theme.searchIcon}`}
           aria-hidden="true"
         >
           <svg
-            className="w-5 h-5"
+            width="20"
+            height="20"
             viewBox="0 0 24 24"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
           >
-            <circle cx="11" cy="11" r="7" />
-            <line x1="16.65" y1="16.65" x2="21" y2="21" />
+            <path
+              d="M21 21L16.514 16.506M19 10.5C19 15.194 15.194 19 10.5 19S2 15.194 2 10.5 5.806 2 10.5 2 19 5.806 19 10.5Z"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
           </svg>
-        </span>
+        </div>
 
         {/* Input field */}
         <input
@@ -135,17 +137,17 @@ export default function SearchBar({
             aria-label="Clear search"
           >
             <svg
-              width="20" 
-              height="20" 
-              viewBox="0 0 24 24" 
-              fill="none" 
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <path 
-                d="M18 6L6 18M6 6L18 18" 
-                stroke="currentColor" 
-                strokeWidth="2" 
-                strokeLinecap="round" 
+              <path
+                d="M18 6L6 18M6 6L18 18"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
                 strokeLinejoin="round"
               />
             </svg>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useState, useEffect } from "react";
-import { Search } from "lucide-react";
 import type { SearchTheme } from "@/lib/market-theme";
 import AttributesFilter from "./AttributesFilter";
 
@@ -70,10 +69,22 @@ export default function SearchBar({
       <div className="relative w-5/6 md:w-2/3 max-w-md">
         {/* Search icon */}
         <span
-          className="absolute left-4 top-1/2 -translate-y-1/2 transform pointer-events-none"
+          className={`absolute left-4 top-1/2 -translate-y-1/2 transform pointer-events-none flex items-center justify-center ${theme.icon}`}
           aria-hidden="true"
         >
-          <Search className={`w-5 h-5 ${theme.icon}`} strokeWidth={2} />
+          <svg
+            className="w-5 h-5"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="11" cy="11" r="7" />
+            <line x1="16.65" y1="16.65" x2="21" y2="21" />
+          </svg>
         </span>
 
         {/* Input field */}

--- a/src/components/VoteButton.tsx
+++ b/src/components/VoteButton.tsx
@@ -13,7 +13,7 @@ export default function VoteButton({
   userRating,
   readOnly = false,
   navigateOnClick = false,
-  showNumber = true,
+  showNumber = false,
   linkSlug,
   compact = false,
 }: {

--- a/src/lib/market-theme.ts
+++ b/src/lib/market-theme.ts
@@ -1,7 +1,7 @@
 import type { Market } from "@prisma/client";
 
 export type SearchTheme = {
-  icon: string;
+  searchIcon: string;
   input: string;
   inputFocus: string;
   filterButton: string;
@@ -94,7 +94,7 @@ type MarketTheme = {
 // Light mode theme for WHITE market
 const WHITE_THEME = {
   search: {
-    icon: "text-green-600",
+    searchIcon: "text-green-600",
     input: "bg-white/60 backdrop-blur-xl border border-gray-200/40 text-gray-900 placeholder-gray-400/60 hover:border-green-300/60",
     inputFocus: "bg-white/70 shadow-2xl shadow-green-100/30 border-green-500/50 backdrop-blur-xl",
     filterButton: "text-green-700 hover:text-green-800",
@@ -125,7 +125,7 @@ const WHITE_THEME = {
     text: "text-gray-600",
   },
   card: {
-    container: "bg-white/60 backdrop-blur-xl border border-gray-200/30 shadow-xl hover:shadow-2xl hover:bg-white/70 text-gray-900",
+    container: "bg-white/60 backdrop-blur-xl border border-gray-200 shadow-xl hover:shadow-2xl hover:bg-white/70 text-gray-900",
     header: "bg-green-800",
     headerOverlay: "bg-green-950/5",
     avatar: "bg-white/80 backdrop-blur-sm shadow-sm",
@@ -133,14 +133,14 @@ const WHITE_THEME = {
     infoText: "text-white",
     category: "text-white/80",
     meta: "text-white/90",
-    action: "bg-white/15 backdrop-blur-xl text-white border border-white/20 hover:bg-white/25",
+    action: "bg-white/15 backdrop-blur-xl text-white border border-gray-200 hover:bg-white/25",
     actionHover: "hover:bg-white/25",
     body: "bg-gray-50/20 backdrop-blur-sm",
-    footer: "text-gray-700 border-t border-gray-200/30",
+    footer: "text-gray-700 border border-gray-200",
     footerHover: "hover:bg-gray-50/30 backdrop-blur-sm",
   },
   strainCard: {
-    container: "bg-white/70 backdrop-blur-xl text-gray-900 hover:bg-gray-50/40 border border-gray-200/30",
+    container: "bg-white/70 backdrop-blur-xl text-gray-900 hover:bg-gray-50/40 border border-gray-200",
     meta: "text-gray-600",
   },
   button: "bg-green-600 hover:bg-green-500 text-white border border-green-500/40 shadow-md hover:shadow-lg",
@@ -169,7 +169,7 @@ const WHITE_THEME = {
 // Gray mode theme for BOTH market
 const BOTH_THEME = {
   search: {
-    icon: "text-green-600",
+    searchIcon: "text-green-600",
     input: "bg-white/50 backdrop-blur-xl border border-gray-300/40 text-gray-900 placeholder-gray-500/60 hover:border-green-400/50",
     inputFocus: "bg-white/60 shadow-2xl shadow-gray-200/30 border-green-500/50 backdrop-blur-xl",
     filterButton: "text-gray-700 hover:text-green-700",
@@ -200,7 +200,7 @@ const BOTH_THEME = {
     text: "text-gray-600",
   },
   card: {
-    container: "bg-white/50 backdrop-blur-xl border border-gray-200/40 shadow-xl hover:shadow-2xl hover:bg-white/60 text-gray-900",
+    container: "bg-white/50 backdrop-blur-xl border border-gray-200 shadow-xl hover:shadow-2xl hover:bg-white/60 text-gray-900",
     header: "bg-green-900",
     headerOverlay: "bg-green-950/5",
     avatar: "bg-white/80 backdrop-blur-sm shadow-sm",
@@ -208,14 +208,14 @@ const BOTH_THEME = {
     infoText: "text-white",
     category: "text-white/80",
     meta: "text-white/90",
-    action: "bg-white/15 backdrop-blur-xl text-white border border-white/20 hover:bg-white/25",
+    action: "bg-white/15 backdrop-blur-xl text-white border border-gray-200 hover:bg-white/25",
     actionHover: "hover:bg-white/25",
     body: "bg-gray-50/15 backdrop-blur-sm",
-    footer: "text-gray-700 border-t border-gray-300/30",
+    footer: "text-gray-700 border border-gray-300",
     footerHover: "hover:bg-gray-50/30 backdrop-blur-sm",
   },
   strainCard: {
-    container: "bg-white/60 backdrop-blur-xl text-gray-900 hover:bg-gray-50/30 border border-gray-200/30",
+    container: "bg-white/60 backdrop-blur-xl text-gray-900 hover:bg-gray-50/30 border border-gray-200",
     meta: "text-gray-600",
   },
   button: "bg-green-600 hover:bg-green-500 text-white border border-green-500/40 shadow-md hover:shadow-lg",
@@ -244,7 +244,7 @@ const BOTH_THEME = {
 // Dark mode theme for BLACK market
 const BLACK_THEME = {
   search: {
-    icon: "text-green-600",
+    searchIcon: "text-green-600",
     input: "bg-zinc-900/80 backdrop-blur-sm border border-zinc-700/60 text-zinc-100 placeholder-gray-400/60 hover:border-green-600/50",
     inputFocus: "bg-zinc-900/90 shadow-xl shadow-green-900/30 border-green-500/60",
     filterButton: "text-green-800 hover:text-green-300",
@@ -275,7 +275,7 @@ const BLACK_THEME = {
     text: "text-gray-300",
   },
   card: {
-    container: "bg-gray-900/70 backdrop-blur-sm border border-gray-700/40 shadow-xl hover:shadow-2xl text-gray-100",
+    container: "bg-gray-900/70 backdrop-blur-sm border border-gray-700 shadow-xl hover:shadow-2xl text-gray-100",
     header: "bg-green-950",
     headerOverlay: "bg-black/10",
     avatar: "bg-gray-800/80 shadow-md",
@@ -283,14 +283,14 @@ const BLACK_THEME = {
     infoText: "text-white",
     category: "text-white/80",
     meta: "text-white/90",
-    action: "bg-white/20 backdrop-blur-sm text-white border border-white/30 hover:bg-white/30",
+    action: "bg-white/20 backdrop-blur-sm text-white border border-white hover:bg-white/30",
     actionHover: "hover:bg-white/30",
     body: "bg-gray-800/30",
-    footer: "text-gray-200 border-t border-gray-600/40",
+    footer: "text-gray-200 border-t border-gray-600",
     footerHover: "hover:bg-gray-800/60",
   },
   strainCard: {
-    container: "bg-gray-900/80 backdrop-blur-sm text-gray-100 hover:bg-gray-800/60 border border-gray-700/30",
+    container: "bg-gray-900/80 backdrop-blur-sm text-gray-100 hover:bg-gray-800/60 border border-gray-700",
     meta: "text-gray-200",
   },
   button: "bg-green-600 hover:bg-green-500 text-white border border-green-500/60 shadow-lg hover:shadow-xl",

--- a/src/lib/market-theme.ts
+++ b/src/lib/market-theme.ts
@@ -28,6 +28,10 @@ export type ToggleTheme = {
     active: string;
     inactive: string;
   };
+  labelWrapper: {
+    flower: string;
+    hash: string;
+  };
   focusRing: string;
 };
 
@@ -147,12 +151,16 @@ const WHITE_THEME = {
       base:
         "absolute left-1.5 top-1.5 bottom-1.5 rounded-full transform transition-all duration-300 ease-out shadow-lg",
       flower: "bg-gradient-to-r from-green-500 to-green-600 translate-x-0 w-24",
-      hash: "bg-gradient-to-r from-green-500 to-green-600 translate-x-24 w-24",
+      hash: "bg-gradient-to-r from-green-500 to-green-600 translate-x-24 w-22",
     },
     label: {
       base: "font-semibold text-sm transition-all duration-300 ease-out",
       active: "text-white drop-shadow-sm",
       inactive: "text-green-700/80 hover:text-green-900",
+    },
+    labelWrapper: {
+      flower: "w-24",
+      hash: "w-22",
     },
     focusRing: "ring-green-300/30 ring-opacity-0 focus-within:ring-opacity-80",
   },
@@ -218,12 +226,16 @@ const BOTH_THEME = {
       base:
         "absolute left-1.5 top-1.5 bottom-1.5 rounded-full transform transition-all duration-300 ease-out shadow-lg",
       flower: "bg-gradient-to-r from-green-500 to-green-600 translate-x-0 w-24",
-      hash: "bg-gradient-to-r from-green-500 to-green-600 translate-x-24 w-24",
+      hash: "bg-gradient-to-r from-green-500 to-green-600 translate-x-24 w-22",
     },
     label: {
       base: "font-semibold text-sm transition-all duration-300 ease-out",
       active: "text-white drop-shadow-sm",
       inactive: "text-gray-600 hover:text-gray-900",
+    },
+    labelWrapper: {
+      flower: "w-24",
+      hash: "w-22",
     },
     focusRing: "ring-green-400/30 ring-opacity-0 focus-within:ring-opacity-80",
   },
@@ -289,12 +301,16 @@ const BLACK_THEME = {
       base:
         "absolute left-1.5 top-1.5 bottom-1.5 rounded-full transform transition-all duration-300 ease-out shadow-lg",
       flower: "bg-gradient-to-r from-green-500 to-green-700 translate-x-0 w-24",
-      hash: "bg-gradient-to-r from-green-600 to-green-700 translate-x-24 w-24",
+      hash: "bg-gradient-to-r from-green-600 to-green-700 translate-x-24 w-22",
     },
     label: {
       base: "font-semibold text-sm transition-all duration-300 ease-out",
       active: "text-white drop-shadow-sm",
       inactive: "text-gray-300 hover:text-white",
+    },
+    labelWrapper: {
+      flower: "w-24",
+      hash: "w-22",
     },
     focusRing: "ring-green-500/30 ring-opacity-0 focus-within:ring-opacity-80",
   },

--- a/src/lib/market-theme.ts
+++ b/src/lib/market-theme.ts
@@ -147,7 +147,7 @@ const WHITE_THEME = {
       base:
         "absolute left-1.5 top-1.5 bottom-1.5 rounded-full transform transition-all duration-300 ease-out shadow-lg",
       flower: "bg-gradient-to-r from-green-500 to-green-600 translate-x-0 w-24",
-      hash: "bg-gradient-to-r from-amber-400 to-amber-500 translate-x-24 w-24",
+      hash: "bg-gradient-to-r from-green-500 to-green-600 translate-x-24 w-24",
     },
     label: {
       base: "font-semibold text-sm transition-all duration-300 ease-out",
@@ -218,7 +218,7 @@ const BOTH_THEME = {
       base:
         "absolute left-1.5 top-1.5 bottom-1.5 rounded-full transform transition-all duration-300 ease-out shadow-lg",
       flower: "bg-gradient-to-r from-green-500 to-green-600 translate-x-0 w-24",
-      hash: "bg-gradient-to-r from-amber-500 to-amber-600 translate-x-24 w-24",
+      hash: "bg-gradient-to-r from-green-500 to-green-600 translate-x-24 w-24",
     },
     label: {
       base: "font-semibold text-sm transition-all duration-300 ease-out",
@@ -289,7 +289,7 @@ const BLACK_THEME = {
       base:
         "absolute left-1.5 top-1.5 bottom-1.5 rounded-full transform transition-all duration-300 ease-out shadow-lg",
       flower: "bg-gradient-to-r from-green-500 to-green-700 translate-x-0 w-24",
-      hash: "bg-gradient-to-r from-amber-500 to-amber-700 translate-x-24 w-24",
+      hash: "bg-gradient-to-r from-green-600 to-green-700 translate-x-24 w-24",
     },
     label: {
       base: "font-semibold text-sm transition-all duration-300 ease-out",

--- a/src/lib/market-theme.ts
+++ b/src/lib/market-theme.ts
@@ -16,6 +16,21 @@ export type SearchTheme = {
   attributeText: string;
 };
 
+export type ToggleTheme = {
+  container: string;
+  indicator: {
+    base: string;
+    flower: string;
+    hash: string;
+  };
+  label: {
+    base: string;
+    active: string;
+    inactive: string;
+  };
+  focusRing: string;
+};
+
 type DropsTheme = {
   page: string;
   hero: {
@@ -53,6 +68,7 @@ type DropsTheme = {
     meta: string;
   };
   button: string;
+  toggle: ToggleTheme;
   search: SearchTheme;
 };
 
@@ -63,6 +79,7 @@ type RankingsTheme = {
   button: string;
   producerCardAppearance: "light" | "gray" | "dark";
   search: SearchTheme;
+  toggle: ToggleTheme;
 };
 
 type MarketTheme = {
@@ -123,6 +140,22 @@ const WHITE_THEME = {
     meta: "text-gray-600",
   },
   button: "bg-green-600 hover:bg-green-500 text-white border border-green-500/40 shadow-md hover:shadow-lg",
+  toggle: {
+    container:
+      "bg-white/70 backdrop-blur-xl border border-green-100/60 shadow-inner shadow-green-100/20",
+    indicator: {
+      base:
+        "absolute left-1.5 top-1.5 bottom-1.5 rounded-full transform transition-all duration-300 ease-out shadow-lg",
+      flower: "bg-gradient-to-r from-green-500 to-green-600 translate-x-0 w-24",
+      hash: "bg-gradient-to-r from-amber-400 to-amber-500 translate-x-24 w-24",
+    },
+    label: {
+      base: "font-semibold text-sm transition-all duration-300 ease-out",
+      active: "text-white drop-shadow-sm",
+      inactive: "text-green-700/80 hover:text-green-900",
+    },
+    focusRing: "ring-green-300/30 ring-opacity-0 focus-within:ring-opacity-80",
+  },
 };
 
 // Gray mode theme for BOTH market
@@ -178,6 +211,22 @@ const BOTH_THEME = {
     meta: "text-gray-600",
   },
   button: "bg-green-600 hover:bg-green-500 text-white border border-green-500/40 shadow-md hover:shadow-lg",
+  toggle: {
+    container:
+      "bg-white/60 backdrop-blur-xl border border-gray-200/60 shadow-inner shadow-gray-200/30",
+    indicator: {
+      base:
+        "absolute left-1.5 top-1.5 bottom-1.5 rounded-full transform transition-all duration-300 ease-out shadow-lg",
+      flower: "bg-gradient-to-r from-green-500 to-green-600 translate-x-0 w-24",
+      hash: "bg-gradient-to-r from-amber-500 to-amber-600 translate-x-24 w-24",
+    },
+    label: {
+      base: "font-semibold text-sm transition-all duration-300 ease-out",
+      active: "text-white drop-shadow-sm",
+      inactive: "text-gray-600 hover:text-gray-900",
+    },
+    focusRing: "ring-green-400/30 ring-opacity-0 focus-within:ring-opacity-80",
+  },
 };
 
 // Dark mode theme for BLACK market
@@ -233,6 +282,22 @@ const BLACK_THEME = {
     meta: "text-gray-200",
   },
   button: "bg-green-600 hover:bg-green-500 text-white border border-green-500/60 shadow-lg hover:shadow-xl",
+  toggle: {
+    container:
+      "bg-zinc-900/80 backdrop-blur-sm border border-zinc-700/70 shadow-inner shadow-black/40",
+    indicator: {
+      base:
+        "absolute left-1.5 top-1.5 bottom-1.5 rounded-full transform transition-all duration-300 ease-out shadow-lg",
+      flower: "bg-gradient-to-r from-green-500 to-green-700 translate-x-0 w-24",
+      hash: "bg-gradient-to-r from-amber-500 to-amber-700 translate-x-24 w-24",
+    },
+    label: {
+      base: "font-semibold text-sm transition-all duration-300 ease-out",
+      active: "text-white drop-shadow-sm",
+      inactive: "text-gray-300 hover:text-white",
+    },
+    focusRing: "ring-green-500/30 ring-opacity-0 focus-within:ring-opacity-80",
+  },
 };
 
 const MARKET_THEME: Record<Market, MarketTheme> = {


### PR DESCRIPTION
## Summary
- add toggle styling to the market themes and thread it through the producer list
- update the CategoryToggle component to consume themed colors
- fix the search icon color handling and adjust the rankings hero copy per market

## Testing
- npm run lint *(fails: ESLint must be installed: npm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68cf8dd0f1d8832d8c21ca3379826b1e