### PR TITLE
Alias Supabase realtime module for Next.js build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,6 @@
 // next.config.js
+const path = require('path');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -20,6 +22,24 @@ const nextConfig = {
         pathname: '/**',
       },
     ],
+  },
+  webpack: (config) => {
+    const realtimeModuleEntry = path.resolve(
+      __dirname,
+      'node_modules/@supabase/realtime-js/dist/module/index.js',
+    );
+
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      '@supabase/realtime-js': realtimeModuleEntry,
+      '@supabase/realtime-js/dist/main': realtimeModuleEntry,
+      '@supabase/realtime-js/dist/main/index.js': realtimeModuleEntry,
+      '@supabase/realtime-js/dist/module': realtimeModuleEntry,
+      '@supabase/realtime-js/dist/module/index.js': realtimeModuleEntry,
+    };
+
+    return config;
   },
 };
 


### PR DESCRIPTION
## Summary
- add a webpack override in Next.js config to alias all realtime-js entry points to the ESM module build

## Testing
- `npm run build` *(fails: Prisma requires DATABASE_URL env var)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f90a7f00832db0b2c78ef4a81b98